### PR TITLE
FGP 39: logout endpoint QA fixes

### DIFF
--- a/src/main/java/gov/cabinetofice/gapuserservice/web/LoginController.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/LoginController.java
@@ -75,7 +75,7 @@ public class LoginController {
 
     @PostMapping("/logout")
     public RedirectView logout(
-            final @CookieValue(name = USER_SERVICE_COOKIE_NAME, required = false) String jwt,
+            final @CookieValue(name = USER_SERVICE_COOKIE_NAME) String jwt,
             final HttpServletResponse response) {
 
         jwtBlacklistService.addJwtToBlacklist(jwt);


### PR DESCRIPTION
Made the JWT cookie value a mandatory method parameter on the logout method