### PR TITLE
Incorrectly secured endpoints

### DIFF
--- a/src/main/java/gov/cabinetofice/gapuserservice/security/WebSecurityConfig.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/security/WebSecurityConfig.java
@@ -42,7 +42,10 @@ public class WebSecurityConfig {
         // specify any paths you don't want subject to JWT validation/authentication
         return web -> web.ignoring().requestMatchers(
                 "/health",
-                "/login");
+                "/login",
+                "/is-user-logged-in",
+                "/redirect-after-cola-login"
+        );
     }
 
     @Bean

--- a/src/main/java/gov/cabinetofice/gapuserservice/validation/validators/EmailAddressMatchMatchValidator.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/validation/validators/EmailAddressMatchMatchValidator.java
@@ -28,13 +28,14 @@ public class EmailAddressMatchMatchValidator implements ConstraintValidator<Emai
 
         final boolean fieldValueIsEmpty = Strings.isEmpty((String) fieldValue);
         final boolean fieldMatchValueIsEmpty = Strings.isEmpty((String) fieldMatchValue);
-        final boolean fieldsMatch = fieldValue.equals(fieldMatchValue); //TODO fix potential null pointer here
 
-        if ((!fieldValueIsEmpty && !fieldMatchValueIsEmpty) && !fieldsMatch) {
-            context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(context.getDefaultConstraintMessageTemplate()).addPropertyNode(field).addConstraintViolation();
-            context.buildConstraintViolationWithTemplate(context.getDefaultConstraintMessageTemplate()).addPropertyNode(fieldMatch).addConstraintViolation();
-            return false;
+        if (!fieldValueIsEmpty && !fieldMatchValueIsEmpty) {
+            if (!fieldValue.equals(fieldMatchValue)) {
+                context.disableDefaultConstraintViolation();
+                context.buildConstraintViolationWithTemplate(context.getDefaultConstraintMessageTemplate()).addPropertyNode(field).addConstraintViolation();
+                context.buildConstraintViolationWithTemplate(context.getDefaultConstraintMessageTemplate()).addPropertyNode(fieldMatch).addConstraintViolation();
+                return false;
+            }
         }
 
         return true;

--- a/src/test/java/gov/cabinetofice/gapuserservice/config/BeanConfigTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/config/BeanConfigTest.java
@@ -20,7 +20,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class BeanConfigTest {
+class BeanConfigTest {
 
     private BeanConfig configUnderTest;
 

--- a/src/test/java/gov/cabinetofice/gapuserservice/scheduler/JwtBlacklistSchedulerTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/scheduler/JwtBlacklistSchedulerTest.java
@@ -16,7 +16,7 @@ import java.time.ZoneId;
 import java.util.Date;
 
 @ExtendWith(MockitoExtension.class)
-public class JwtBlacklistSchedulerTest {
+class JwtBlacklistSchedulerTest {
 
     @Mock
     private JwtBlacklistService jwtBlacklistService;

--- a/src/test/java/gov/cabinetofice/gapuserservice/security/JwtTokenFilterTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/security/JwtTokenFilterTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class JwtTokenFilterTest {
+class JwtTokenFilterTest {
 
     private JwtTokenFilter jwtTokenFilter;
     private @Mock DebugProperties debugProperties;
@@ -57,7 +57,7 @@ public class JwtTokenFilterTest {
         when(customJwtServiceImpl.isTokenValid("value")).thenReturn(true);
 
         try (MockedStatic<SecurityContextHolder> staticSecurityContextHolder = Mockito.mockStatic(SecurityContextHolder.class)) {
-            staticSecurityContextHolder.when(() -> SecurityContextHolder.getContext()).thenReturn(securityContext);
+            staticSecurityContextHolder.when(SecurityContextHolder::getContext).thenReturn(securityContext);
 
             jwtTokenFilter.doFilterInternal(request, response, chain);
 
@@ -78,7 +78,7 @@ public class JwtTokenFilterTest {
         when(debugProperties.isIgnoreJwt()).thenReturn(true);
 
         try (MockedStatic<SecurityContextHolder> staticSecurityContextHolder = Mockito.mockStatic(SecurityContextHolder.class)) {
-            staticSecurityContextHolder.when(() -> SecurityContextHolder.getContext()).thenReturn(securityContext);
+            staticSecurityContextHolder.when(SecurityContextHolder::getContext).thenReturn(securityContext);
 
             jwtTokenFilter.doFilterInternal(request, response, chain);
 
@@ -96,7 +96,7 @@ public class JwtTokenFilterTest {
         when(request.getCookies()).thenReturn(new Cookie[]{});
 
         try (MockedStatic<SecurityContextHolder> staticSecurityContextHolder = Mockito.mockStatic(SecurityContextHolder.class)) {
-            staticSecurityContextHolder.when(() -> SecurityContextHolder.getContext()).thenReturn(securityContext);
+            staticSecurityContextHolder.when(SecurityContextHolder::getContext).thenReturn(securityContext);
 
             jwtTokenFilter.doFilterInternal(request, response, chain);
 
@@ -112,7 +112,7 @@ public class JwtTokenFilterTest {
         when(request.getCookies()).thenReturn(new Cookie[]{});
 
         try (MockedStatic<SecurityContextHolder> staticSecurityContextHolder = Mockito.mockStatic(SecurityContextHolder.class)) {
-            staticSecurityContextHolder.when(() -> SecurityContextHolder.getContext()).thenReturn(securityContext);
+            staticSecurityContextHolder.when(SecurityContextHolder::getContext).thenReturn(securityContext);
 
             jwtTokenFilter.doFilterInternal(request, response, chain);
 
@@ -128,7 +128,7 @@ public class JwtTokenFilterTest {
         when(request.getCookies()).thenReturn(new Cookie[]{});
 
         try (MockedStatic<SecurityContextHolder> staticSecurityContextHolder = Mockito.mockStatic(SecurityContextHolder.class)) {
-            staticSecurityContextHolder.when(() -> SecurityContextHolder.getContext()).thenReturn(securityContext);
+            staticSecurityContextHolder.when(SecurityContextHolder::getContext).thenReturn(securityContext);
 
             jwtTokenFilter.doFilterInternal(request, response, chain);
 
@@ -146,7 +146,7 @@ public class JwtTokenFilterTest {
         when(customJwtServiceImpl.isTokenValid("value")).thenReturn(false);
 
         try (MockedStatic<SecurityContextHolder> staticSecurityContextHolder = Mockito.mockStatic(SecurityContextHolder.class)) {
-            staticSecurityContextHolder.when(() -> SecurityContextHolder.getContext()).thenReturn(securityContext);
+            staticSecurityContextHolder.when(SecurityContextHolder::getContext).thenReturn(securityContext);
 
             final UnauthorizedException error = assertThrows(UnauthorizedException.class, () -> jwtTokenFilter.doFilterInternal(request, response, chain));
             assertThat(error.getMessage()).isEqualTo("Token not valid");

--- a/src/test/java/gov/cabinetofice/gapuserservice/service/jwt/ColaJwtServiceImplTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/service/jwt/ColaJwtServiceImplTest.java
@@ -46,7 +46,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class ColaJwtServiceImplTest {
+class ColaJwtServiceImplTest {
 
     @Mock
     private JwkProvider jwkProvider;


### PR DESCRIPTION
- Adding some endpoints as security filter exceptions in `WebSecurityConfig.java` so that unauthenticated users can access them.
- Fixing sonar lint suggestions