### PR TITLE
Fixing a previously badly configured migration

### DIFF
--- a/src/main/resources/db/migration/V1_2__add_token_blacklist_table.sql
+++ b/src/main/resources/db/migration/V1_2__add_token_blacklist_table.sql
@@ -1,2 +1,6 @@
-create table token_blacklist (id integer not null, expiry_date timestamp(6), jwt varchar(4000), primary key (id));
-create index IDXs5liqeg06eex956w4sv6wuwau on token_blacklist (jwt);
+CREATE SEQUENCE IF NOT EXISTS token_blacklist_seq
+INCREMENT 1
+START 1;
+
+create table if not exists token_blacklist (id integer not null default nextval('token_blacklist_seq'::regclass), expiry_date timestamp(6), jwt varchar(4000), primary key (id));
+create index if not exists IDXs5liqeg06eex956w4sv6wuwau on token_blacklist (jwt);

--- a/src/main/resources/db/migration/V1_3__add_token_blacklist_sequence.sql
+++ b/src/main/resources/db/migration/V1_3__add_token_blacklist_sequence.sql
@@ -1,3 +1,0 @@
-CREATE SEQUENCE token_blacklist_seq
-INCREMENT 1
-START 1;


### PR DESCRIPTION
The migration to create the token blacklist table was previously wrongly configured. This was causing errors when trying to refresh tokens and log out of the user service. This change ensures that an appropriate sequence is created and used as the default value for each new entry in the ID column 