### PR TITLE
Feature/gap 1935 redirect after one login

### DIFF
--- a/src/main/java/gov/cabinetofice/gapuserservice/dto/OneLoginUserInfoDto.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/dto/OneLoginUserInfoDto.java
@@ -1,0 +1,11 @@
+package gov.cabinetofice.gapuserservice.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class OneLoginUserInfoDto {
+    private String email;
+    private String sub;
+}

--- a/src/main/java/gov/cabinetofice/gapuserservice/exceptions/RoleNotFoundException.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/exceptions/RoleNotFoundException.java
@@ -1,0 +1,7 @@
+package gov.cabinetofice.gapuserservice.exceptions;
+
+public class RoleNotFoundException extends RuntimeException {
+    public RoleNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/gov/cabinetofice/gapuserservice/exceptions/UserNotFoundException.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/exceptions/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package gov.cabinetofice.gapuserservice.exceptions;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/gov/cabinetofice/gapuserservice/model/Department.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/model/Department.java
@@ -1,0 +1,35 @@
+package gov.cabinetofice.gapuserservice.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "departments")
+public class Department {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "ggis_id")
+    private String ggisID;
+
+    @Column(name = "users")
+    @OneToMany(mappedBy="id", cascade = { CascadeType.MERGE, CascadeType.PERSIST }, fetch = FetchType.LAZY)
+    @ToString.Exclude
+    @JsonIgnoreProperties({ "hibernateLazyInitializer" })
+    private List<User> users;
+}

--- a/src/main/java/gov/cabinetofice/gapuserservice/model/Department.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/model/Department.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -31,5 +32,6 @@ public class Department {
     @OneToMany(mappedBy="id", cascade = { CascadeType.MERGE, CascadeType.PERSIST }, fetch = FetchType.LAZY)
     @ToString.Exclude
     @JsonIgnoreProperties({ "hibernateLazyInitializer" })
-    private List<User> users;
+    @Builder.Default
+    private List<User> users = new ArrayList<>();
 }

--- a/src/main/java/gov/cabinetofice/gapuserservice/model/Role.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/model/Role.java
@@ -1,0 +1,39 @@
+package gov.cabinetofice.gapuserservice.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "roles")
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+
+    @Column(name = "name")
+    @Enumerated(EnumType.STRING)
+    private RoleEnum name;
+
+    @ManyToMany(cascade = { CascadeType.MERGE, CascadeType.PERSIST }, fetch = FetchType.LAZY)
+    @JoinColumn(name = "id", nullable = false)
+    @ToString.Exclude
+    @JsonIgnoreProperties({ "hibernateLazyInitializer" })
+    private List<User> users;
+
+    public void addUser(User user) {
+        this.users.add(user);
+        user.addRole(this);
+    }
+}
+

--- a/src/main/java/gov/cabinetofice/gapuserservice/model/Role.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/model/Role.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -29,11 +30,11 @@ public class Role {
     @JoinColumn(name = "id", nullable = false)
     @ToString.Exclude
     @JsonIgnoreProperties({ "hibernateLazyInitializer" })
-    private List<User> users;
+    @Builder.Default
+    private List<User> users = new ArrayList<>();
 
     public void addUser(User user) {
         this.users.add(user);
-        user.addRole(this);
     }
 }
 

--- a/src/main/java/gov/cabinetofice/gapuserservice/model/RoleEnum.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/model/RoleEnum.java
@@ -1,0 +1,8 @@
+package gov.cabinetofice.gapuserservice.model;
+
+public enum RoleEnum {
+    SUPERADMIN,
+    ADMIN,
+    APPLICANT,
+    FIND,
+}

--- a/src/main/java/gov/cabinetofice/gapuserservice/model/RoleEnum.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/model/RoleEnum.java
@@ -1,7 +1,7 @@
 package gov.cabinetofice.gapuserservice.model;
 
 public enum RoleEnum {
-    SUPERADMIN,
+    SUPER_ADMIN,
     ADMIN,
     APPLICANT,
     FIND,

--- a/src/main/java/gov/cabinetofice/gapuserservice/model/User.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/model/User.java
@@ -6,7 +6,6 @@ import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -46,10 +45,6 @@ public class User {
         role.addUser(this);
     }
 
-    public List<RoleEnum> getUsersRoles() {
-        return this.roles.stream().map(Role::getName).collect(Collectors.toList());
-    }
-
     public boolean hasSub() {
         return this.sub != null;
     }
@@ -59,17 +54,14 @@ public class User {
     }
 
     public boolean isAnApplicant() {
-        final List<RoleEnum> userRoles = getUsersRoles();
-        return !isAnAdmin() && userRoles.stream().anyMatch((role) -> role.equals(RoleEnum.APPLICANT));
+        return !isAnAdmin() && this.roles.stream().anyMatch((role) -> role.getName().equals(RoleEnum.APPLICANT));
     }
 
     public boolean isAnAdmin() {
-        final List<RoleEnum> userRoles = getUsersRoles();
-        return userRoles.stream().anyMatch((role) -> role.equals(RoleEnum.ADMIN) || role.equals(RoleEnum.SUPER_ADMIN));
+        return this.roles.stream().anyMatch((role) -> role.getName().equals(RoleEnum.ADMIN) || role.getName().equals(RoleEnum.SUPER_ADMIN));
     }
 
     public boolean isASuperAdmin() {
-        final List<RoleEnum> userRoles = getUsersRoles();
-        return userRoles.stream().anyMatch((role) -> role.equals(RoleEnum.SUPER_ADMIN));
+        return this.roles.stream().anyMatch((role) -> role.getName().equals(RoleEnum.SUPER_ADMIN));
     }
 }

--- a/src/main/java/gov/cabinetofice/gapuserservice/model/User.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/model/User.java
@@ -22,32 +22,26 @@ public class User {
     @Column(name = "gap_user_id")
     private Integer id;
 
-    @Column(name = "hashedemail")
-    private String hashedEmail;
-
-    @Column(name = "encryptedemail")
-    private String encryptedEmail;
+    @Column(name = "email")
+    private String email;
 
     @Column(name = "sub")
     private String sub;
 
-    @Column(name = "dept_id")
-    private String departmentId;
-
-    @ManyToMany(cascade = { CascadeType.MERGE, CascadeType.PERSIST }, fetch = FetchType.LAZY)
-    @JoinColumn(name = "id", nullable = false)
+    @ManyToMany(cascade = { CascadeType.MERGE, CascadeType.PERSIST }, fetch = FetchType.LAZY, mappedBy = "users")
     @ToString.Exclude
     @JsonIgnoreProperties({ "hibernateLazyInitializer" })
     @Builder.Default
     private List<Role> roles = new ArrayList<>();
 
     @ManyToOne(cascade = { CascadeType.MERGE, CascadeType.PERSIST }, fetch = FetchType.LAZY)
-    @JoinColumn(name = "id")
+    @JoinColumn(name = "dept_id")
     @ToString.Exclude
     @JsonIgnoreProperties({ "hibernateLazyInitializer" })
     private Department department;
 
     public void addRole(final Role role) {
         this.roles.add(role);
+        role.addUser(this);
     }
 }

--- a/src/main/java/gov/cabinetofice/gapuserservice/model/User.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/model/User.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -37,7 +38,8 @@ public class User {
     @JoinColumn(name = "id", nullable = false)
     @ToString.Exclude
     @JsonIgnoreProperties({ "hibernateLazyInitializer" })
-    private List<Role> roles;
+    @Builder.Default
+    private List<Role> roles = new ArrayList<>();
 
     @ManyToOne(cascade = { CascadeType.MERGE, CascadeType.PERSIST }, fetch = FetchType.LAZY)
     @JoinColumn(name = "id")
@@ -47,6 +49,5 @@ public class User {
 
     public void addRole(final Role role) {
         this.roles.add(role);
-        role.addUser(this);
     }
 }

--- a/src/main/java/gov/cabinetofice/gapuserservice/model/User.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/model/User.java
@@ -53,15 +53,15 @@ public class User {
         return this.email != null;
     }
 
-    public boolean isAnApplicant() {
-        return !isAnAdmin() && this.roles.stream().anyMatch((role) -> role.getName().equals(RoleEnum.APPLICANT));
+    public boolean isApplicant() {
+        return !isAdmin() && this.roles.stream().anyMatch((role) -> role.getName().equals(RoleEnum.APPLICANT));
     }
 
-    public boolean isAnAdmin() {
+    public boolean isAdmin() {
         return this.roles.stream().anyMatch((role) -> role.getName().equals(RoleEnum.ADMIN) || role.getName().equals(RoleEnum.SUPER_ADMIN));
     }
 
-    public boolean isASuperAdmin() {
+    public boolean isSuperAdmin() {
         return this.roles.stream().anyMatch((role) -> role.getName().equals(RoleEnum.SUPER_ADMIN));
     }
 }

--- a/src/main/java/gov/cabinetofice/gapuserservice/model/User.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/model/User.java
@@ -1,0 +1,52 @@
+package gov.cabinetofice.gapuserservice.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "gap_users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "gap_user_id")
+    private Integer id;
+
+    @Column(name = "hashedemail")
+    private String hashedEmail;
+
+    @Column(name = "encryptedemail")
+    private String encryptedEmail;
+
+    @Column(name = "sub")
+    private String sub;
+
+    @Column(name = "dept_id")
+    private String departmentId;
+
+    @ManyToMany(cascade = { CascadeType.MERGE, CascadeType.PERSIST }, fetch = FetchType.LAZY)
+    @JoinColumn(name = "id", nullable = false)
+    @ToString.Exclude
+    @JsonIgnoreProperties({ "hibernateLazyInitializer" })
+    private List<Role> roles;
+
+    @ManyToOne(cascade = { CascadeType.MERGE, CascadeType.PERSIST }, fetch = FetchType.LAZY)
+    @JoinColumn(name = "id")
+    @ToString.Exclude
+    @JsonIgnoreProperties({ "hibernateLazyInitializer" })
+    private Department department;
+
+    public void addRole(final Role role) {
+        this.roles.add(role);
+        role.addUser(this);
+    }
+}

--- a/src/main/java/gov/cabinetofice/gapuserservice/model/User.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/model/User.java
@@ -6,6 +6,7 @@ import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -28,13 +29,13 @@ public class User {
     @Column(name = "sub")
     private String sub;
 
-    @ManyToMany(cascade = { CascadeType.MERGE, CascadeType.PERSIST }, fetch = FetchType.LAZY, mappedBy = "users")
+    @ManyToMany(cascade = { CascadeType.MERGE, CascadeType.PERSIST }, fetch = FetchType.EAGER, mappedBy = "users")
     @ToString.Exclude
     @JsonIgnoreProperties({ "hibernateLazyInitializer" })
     @Builder.Default
     private List<Role> roles = new ArrayList<>();
 
-    @ManyToOne(cascade = { CascadeType.MERGE, CascadeType.PERSIST }, fetch = FetchType.LAZY)
+    @ManyToOne(cascade = { CascadeType.MERGE, CascadeType.PERSIST }, fetch = FetchType.EAGER)
     @JoinColumn(name = "dept_id")
     @ToString.Exclude
     @JsonIgnoreProperties({ "hibernateLazyInitializer" })
@@ -43,5 +44,32 @@ public class User {
     public void addRole(final Role role) {
         this.roles.add(role);
         role.addUser(this);
+    }
+
+    public List<RoleEnum> getUsersRoles() {
+        return this.roles.stream().map(Role::getName).collect(Collectors.toList());
+    }
+
+    public boolean hasSub() {
+        return this.sub != null;
+    }
+
+    public boolean hasEmail() {
+        return this.email != null;
+    }
+
+    public boolean isAnApplicant() {
+        final List<RoleEnum> userRoles = getUsersRoles();
+        return !isAnAdmin() && userRoles.stream().anyMatch((role) -> role.equals(RoleEnum.APPLICANT));
+    }
+
+    public boolean isAnAdmin() {
+        final List<RoleEnum> userRoles = getUsersRoles();
+        return userRoles.stream().anyMatch((role) -> role.equals(RoleEnum.ADMIN) || role.equals(RoleEnum.SUPER_ADMIN));
+    }
+
+    public boolean isASuperAdmin() {
+        final List<RoleEnum> userRoles = getUsersRoles();
+        return userRoles.stream().anyMatch((role) -> role.equals(RoleEnum.SUPER_ADMIN));
     }
 }

--- a/src/main/java/gov/cabinetofice/gapuserservice/repository/JwtBlacklistRepository.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/repository/JwtBlacklistRepository.java
@@ -2,9 +2,11 @@ package gov.cabinetofice.gapuserservice.repository;
 
 import gov.cabinetofice.gapuserservice.model.BlacklistedToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 
+@Repository
 public interface JwtBlacklistRepository extends JpaRepository <BlacklistedToken, String> {
 
     long deleteByExpiryDateLessThan(LocalDateTime expiryDate);

--- a/src/main/java/gov/cabinetofice/gapuserservice/repository/RoleRepository.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/repository/RoleRepository.java
@@ -1,0 +1,14 @@
+package gov.cabinetofice.gapuserservice.repository;
+
+import gov.cabinetofice.gapuserservice.model.Role;
+import gov.cabinetofice.gapuserservice.model.RoleEnum;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RoleRepository extends JpaRepository<Role, Integer> {
+    Optional<Role> findByName(RoleEnum name);
+}
+

--- a/src/main/java/gov/cabinetofice/gapuserservice/repository/RoleRepository.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/repository/RoleRepository.java
@@ -5,13 +5,10 @@ import gov.cabinetofice.gapuserservice.model.RoleEnum;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface RoleRepository extends JpaRepository<Role, Integer> {
     Optional<Role> findByName(RoleEnum name);
-    List<Role> findByUsers_Email(String email);
-    List<Role> findByUsers_Sub(String sub);
 }
 

--- a/src/main/java/gov/cabinetofice/gapuserservice/repository/RoleRepository.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/repository/RoleRepository.java
@@ -5,10 +5,13 @@ import gov.cabinetofice.gapuserservice.model.RoleEnum;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface RoleRepository extends JpaRepository<Role, Integer> {
     Optional<Role> findByName(RoleEnum name);
+    List<Role> findByUsers_Email(String email);
+    List<Role> findByUsers_Sub(String sub);
 }
 

--- a/src/main/java/gov/cabinetofice/gapuserservice/repository/UserRepository.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/repository/UserRepository.java
@@ -8,9 +8,7 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Integer> {
-    boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
-    boolean existsBySub(String sub);
     Optional<User> findBySub(String sub);
 }
 

--- a/src/main/java/gov/cabinetofice/gapuserservice/repository/UserRepository.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/repository/UserRepository.java
@@ -8,9 +8,9 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Integer> {
-    boolean existsByHashedEmail(String hashedEmail);
+    boolean existsByEmail(String email);
+    Optional<User> findByEmail(String email);
     boolean existsBySub(String sub);
-    Optional<User> findByHashedEmail(String hashedEmail);
     Optional<User> findBySub(String sub);
 }
 

--- a/src/main/java/gov/cabinetofice/gapuserservice/repository/UserRepository.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/repository/UserRepository.java
@@ -1,0 +1,16 @@
+package gov.cabinetofice.gapuserservice.repository;
+
+import gov.cabinetofice.gapuserservice.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Integer> {
+    boolean existsByHashedEmail(String hashedEmail);
+    boolean existsBySub(String sub);
+    Optional<User> findByHashedEmail(String hashedEmail);
+    Optional<User> findBySub(String sub);
+}
+

--- a/src/main/java/gov/cabinetofice/gapuserservice/security/WebSecurityConfig.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/security/WebSecurityConfig.java
@@ -46,6 +46,7 @@ public class WebSecurityConfig {
                 "/health",
                 "/login",
                 "/v2/redirect-after-login",
+                "/v2/login",
                 "/is-user-logged-in",
                 "/redirect-after-cola-login",
                 "/error/**",

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/OneLoginService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/OneLoginService.java
@@ -136,10 +136,7 @@ public class OneLoginService {
     }
 
     public List<RoleEnum> getNewUserRoles() {
-        final List<RoleEnum> newUserRoles = new ArrayList<>();
-        newUserRoles.add(RoleEnum.APPLICANT);
-        newUserRoles.add(RoleEnum.FIND);
-        return newUserRoles;
+        return List.of(RoleEnum.APPLICANT, RoleEnum.FIND);
     }
 
     public boolean isUserAnApplicant(final List<RoleEnum> userRoles) {

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
@@ -1,13 +1,31 @@
 package gov.cabinetofice.gapuserservice.web;
 
+import gov.cabinetofice.gapuserservice.config.ApplicationConfigProperties;
+import gov.cabinetofice.gapuserservice.model.RoleEnum;
 import gov.cabinetofice.gapuserservice.service.OneLoginService;
+import gov.cabinetofice.gapuserservice.service.jwt.impl.CustomJwtServiceImpl;
+import gov.cabinetofice.gapuserservice.util.WebUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.view.RedirectView;
+import org.springframework.web.util.WebUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static gov.cabinetofice.gapuserservice.web.LoginController.REDIRECT_URL_COOKIE;
 
 
 @RequiredArgsConstructor
@@ -17,16 +35,92 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class LoginControllerV2 {
 
     private final OneLoginService oneLoginService;
+    private final CustomJwtServiceImpl customJwtService;
+    private final ApplicationConfigProperties configProperties;
+
+    @Value("${jwt.cookie-name}")
+    public String userServiceCookieName;
+
+    @Value("${onelogin.base-url}")
+    private String oneLoginBaseUrl;
+
+    @GetMapping("/login")
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    public RedirectView login(final @RequestParam Optional<String> redirectUrl,
+                              final HttpServletRequest request,
+                              final HttpServletResponse response) {
+        final Cookie customJWTCookie = WebUtils.getCookie(request, userServiceCookieName);
+
+        final boolean isTokenValid = customJWTCookie != null
+                && customJWTCookie.getValue() != null
+                && customJwtService.isTokenValid(customJWTCookie.getValue());
+        if (!isTokenValid) {
+            final Cookie redirectUrlCookie = WebUtil.buildCookie(
+                    new Cookie(REDIRECT_URL_COOKIE, redirectUrl.orElse(configProperties.getDefaultRedirectUrl())),
+                    Boolean.TRUE,
+                    Boolean.TRUE,
+                    null
+            );
+
+            response.addCookie(redirectUrlCookie);
+
+            // TODO check if this is the correct URL
+            return new RedirectView(oneLoginBaseUrl + "/login");
+        }
+
+        return new RedirectView(redirectUrl.orElse(configProperties.getDefaultRedirectUrl()));
+    }
 
     @GetMapping("/redirect-after-login")
-    public ResponseEntity<String> redirect(final @RequestParam String code) {
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    public RedirectView redirect(final @CookieValue(name = REDIRECT_URL_COOKIE) Optional<String> redirectUrl,
+                                 final HttpServletRequest request,
+                                 final HttpServletResponse response,
+                                 final @RequestParam String code) {
 
-        String jwt = oneLoginService.createOneLoginJwt();
-        String authToken = oneLoginService.getAuthToken(jwt, code);
-        String userInfo = oneLoginService.getUserInfo(authToken);
+        // 1. Grab user info from OneLogin
+        final String jwt = oneLoginService.createOneLoginJwt();
+        final String authToken = oneLoginService.getAuthToken(jwt, code);
+        final JSONObject userInfo = oneLoginService.getUserInfo(authToken);
+        final String sub = userInfo.getString("sub");
+        final String email = userInfo.getString("email");
 
-        // Temporarily returning user info here for testing purposes
-        return ResponseEntity.ok(userInfo);
+        // 2. Check if user is in the database
+        boolean userExistsByEmail = oneLoginService.doesUserExistByEmail(email);
+        boolean userExistsBySub = oneLoginService.doesUserExistBySub(sub);
+
+        if(!userExistsByEmail) {
+            // 3. If user is not in the database, create a new user
+            oneLoginService.createUser(sub, email);
+        } else if(!userExistsBySub) {
+            // 4. If user is in the database, but has not used OneLogin before, update user info
+            oneLoginService.addSubToUser(sub, email);
+        }
+
+        // 5. Create user service custom jwt from user info
+        final Map<String, String> claims = new HashMap<>();
+        claims.put("email", email);
+        claims.put("sub", sub);
+
+        final Cookie userTokenCookie = WebUtil.buildCookie(
+                new Cookie(userServiceCookieName, customJwtService.generateToken(claims)),
+                Boolean.TRUE,
+                Boolean.TRUE,
+                null
+        );
+
+        response.addCookie(userTokenCookie);
+
+        // 6. Check the users roles and redirect to the correct page
+        final List<RoleEnum> usersRoles = oneLoginService.getUsersRoles(sub);
+
+        boolean isSuperAdmin = usersRoles.stream().anyMatch((role) -> role.equals(RoleEnum.SUPERADMIN));
+        if(isSuperAdmin) return new RedirectView("Super admin dashboard"); // TODO fetch url from somewhere
+
+        boolean isAdmin = usersRoles.stream().anyMatch((role) -> role.equals(RoleEnum.ADMIN));
+        if(isAdmin) return new RedirectView("Admin dashboard"); // TODO fetch url from somewhere
+
+        return new RedirectView(redirectUrl.orElse(configProperties.getDefaultRedirectUrl()));
     }
 
 }

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
@@ -89,7 +89,7 @@ public class LoginControllerV2 {
         if (userOptional.isPresent()) {
             final User user = userOptional.get();
             if (user.hasSub()) return getRedirectView(user, redirectUrl);
-            if (user.isAnApplicant()) {
+            if (user.isApplicant()) {
                 // TODO GAP-1922: Create migration page with a yes/no option
                 return new RedirectView("/should-migrate-data");
             } else {
@@ -120,8 +120,8 @@ public class LoginControllerV2 {
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     private RedirectView getRedirectView(final User user, final Optional<String> redirectUrl) {
-        if(user.isASuperAdmin()) return new RedirectView(adminBaseUrl + "/super-admin/dashboard");
-        if(user.isAnAdmin()) return new RedirectView(adminBaseUrl + "/dashboard");
+        if(user.isSuperAdmin()) return new RedirectView(adminBaseUrl + "/super-admin/dashboard");
+        if(user.isAdmin()) return new RedirectView(adminBaseUrl + "/dashboard");
         return new RedirectView((redirectUrl.orElse(configProperties.getDefaultRedirectUrl())));
     }
 

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
@@ -113,7 +113,7 @@ public class LoginControllerV2 {
     private String getRedirectUrl(final String sub, final Optional<String> redirectUrl) {
         final List<RoleEnum> usersRoles = oneLoginService.getUsersRoles(sub);
 
-        boolean isSuperAdmin = usersRoles.stream().anyMatch((role) -> role.equals(RoleEnum.SUPERADMIN));
+        boolean isSuperAdmin = usersRoles.stream().anyMatch((role) -> role.equals(RoleEnum.SUPER_ADMIN));
         if(isSuperAdmin) return adminBaseUrl + "/super-admin/dashboard";
 
         boolean isAdmin = usersRoles.stream().anyMatch((role) -> role.equals(RoleEnum.ADMIN));

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
@@ -82,8 +82,8 @@ public class LoginControllerV2 {
         final String authToken = oneLoginService.getAuthToken(jwt, code);
         final OneLoginUserInfoDto userInfo = oneLoginService.getUserInfo(authToken);
         final Optional<User> userOptional = oneLoginService.getUser(userInfo.getEmail(), userInfo.getSub());
-        final Cookie customJwt = generateCustomJwtCookie(userInfo);
 
+        final Cookie customJwt = generateCustomJwtCookie(userInfo);
         response.addCookie(customJwt);
 
         if (userOptional.isPresent()) {
@@ -94,7 +94,7 @@ public class LoginControllerV2 {
                 return new RedirectView("/should-migrate-data");
             } else {
                 // TODO GAP-1932: Migrate cola user data to this admin
-                oneLoginService.addSubToUser(userInfo.getSub(), userInfo.getEmail());
+                oneLoginService.addSubToUser(user.getSub(), user.getEmail());
                 return getRedirectView(user, redirectUrl);
             }
         }
@@ -107,6 +107,8 @@ public class LoginControllerV2 {
         final Map<String, String> claims = new HashMap<>();
         claims.put("email", userInfo.getEmail());
         claims.put("sub", userInfo.getSub());
+        // TODO Add roles to claims
+        // TODO Add department details to claims
 
         return WebUtil.buildCookie(
                 new Cookie(userServiceCookieName, customJwtService.generateToken(claims)),

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
@@ -94,7 +94,7 @@ public class LoginControllerV2 {
                 return new RedirectView("/should-migrate-data");
             } else {
                 // TODO GAP-1932: Migrate cola user data to this admin
-                oneLoginService.addSubToUser(user.getSub(), user.getEmail());
+                oneLoginService.addSubToUser(userInfo.getSub(), user.getEmail());
                 return getRedirectView(user, redirectUrl);
             }
         }

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
@@ -82,8 +82,11 @@ public class LoginControllerV2 {
         final String authToken = oneLoginService.getAuthToken(jwt, code);
         final OneLoginUserInfoDto userInfo = oneLoginService.getUserInfo(authToken);
         final Optional<User> userOptional = oneLoginService.getUser(userInfo.getEmail(), userInfo.getSub());
+        final Cookie customJwt = generateCustomJwtCookie(userInfo);
 
-        if(userOptional.isPresent()) {
+        response.addCookie(customJwt);
+
+        if (userOptional.isPresent()) {
             final User user = userOptional.get();
             if (user.hasSub()) return getRedirectView(user, redirectUrl);
             if (user.isAnApplicant()) {

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
@@ -44,8 +44,8 @@ public class LoginControllerV2 {
     @Value("${onelogin.base-url}")
     private String oneLoginBaseUrl;
 
-    @GetMapping("/login")
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    @GetMapping("/login")
     public RedirectView login(final @RequestParam Optional<String> redirectUrl,
                               final HttpServletRequest request,
                               final HttpServletResponse response) {
@@ -65,14 +65,14 @@ public class LoginControllerV2 {
             response.addCookie(redirectUrlCookie);
 
             // TODO check if this is the correct URL
-            return new RedirectView(oneLoginBaseUrl + "/login");
+            return new RedirectView(oneLoginBaseUrl);
         }
 
         return new RedirectView(redirectUrl.orElse(configProperties.getDefaultRedirectUrl()));
     }
 
-    @GetMapping("/redirect-after-login")
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    @GetMapping("/redirect-after-login")
     public RedirectView redirect(final @CookieValue(name = REDIRECT_URL_COOKIE) Optional<String> redirectUrl,
                                  final HttpServletRequest request,
                                  final HttpServletResponse response,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -54,3 +54,5 @@ onelogin.client-assertion-type=assertionTypeValue
 onelogin.service-redirect-url=redirectUrlValue
 onelogin.private-key=privateKeyValue
 feature.onelogin.enabled=false
+
+admin-base-url=http://localhost:3000/apply/admin

--- a/src/main/resources/db/migration/V1_4__update_user_tables.sql
+++ b/src/main/resources/db/migration/V1_4__update_user_tables.sql
@@ -1,0 +1,33 @@
+DROP TABLE departments;
+DROP TABLE gap_users;
+DROP TABLE roles;
+DROP TABLE user_roles;
+
+CREATE TABLE departments (
+	id serial4 NOT NULL,
+	ggis_id varchar(255) NULL,
+	"name" varchar(255) NULL,
+	CONSTRAINT departments_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE gap_users (
+	gap_user_id serial4 NOT NULL,
+	email varchar(255) NULL,
+	sub varchar(255) NULL,
+	dept_id int4 NULL,
+	CONSTRAINT gap_users_pkey PRIMARY KEY (gap_user_id),
+	CONSTRAINT fk9oau3dd02gl4ersfjey0pg5d5 FOREIGN KEY (dept_id) REFERENCES departments(id)
+);
+
+CREATE TABLE roles (
+	id serial4 NOT NULL,
+	"name" varchar(255) NULL,
+	CONSTRAINT roles_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE roles_users (
+	roles_id int4 NOT NULL,
+	users_gap_user_id int4 NOT NULL,
+	CONSTRAINT fk2mck5s7km22t2on8h2jpn44xq FOREIGN KEY (roles_id) REFERENCES roles(id),
+	CONSTRAINT fkhu2gdj9we2ucvgwy1qdfm5a5s FOREIGN KEY (users_gap_user_id) REFERENCES gap_users(gap_user_id)
+);

--- a/src/main/resources/db/migration/V1_4__update_user_tables.sql
+++ b/src/main/resources/db/migration/V1_4__update_user_tables.sql
@@ -1,7 +1,7 @@
-DROP TABLE departments;
-DROP TABLE gap_users;
-DROP TABLE roles;
 DROP TABLE user_roles;
+DROP TABLE gap_users;
+DROP TABLE departments;
+DROP TABLE roles;
 
 CREATE TABLE departments (
 	id serial4 NOT NULL,
@@ -31,3 +31,9 @@ CREATE TABLE roles_users (
 	CONSTRAINT fk2mck5s7km22t2on8h2jpn44xq FOREIGN KEY (roles_id) REFERENCES roles(id),
 	CONSTRAINT fkhu2gdj9we2ucvgwy1qdfm5a5s FOREIGN KEY (users_gap_user_id) REFERENCES gap_users(gap_user_id)
 );
+
+INSERT INTO roles (name) VALUES
+  ('APPLICANT'),
+  ('FIND'),
+  ('ADMIN'),
+  ('SUPER_ADMIN');

--- a/src/test/java/gov/cabinetofice/gapuserservice/model/UserTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/model/UserTest.java
@@ -22,7 +22,7 @@ public class UserTest {
             );
             final User user = User.builder().roles(roles).build();
 
-            final boolean response = user.isAnApplicant();
+            final boolean response = user.isApplicant();
 
             Assertions.assertFalse(response);
         }
@@ -37,7 +37,7 @@ public class UserTest {
             );
             final User user = User.builder().roles(roles).build();
 
-            final boolean response = user.isAnApplicant();
+            final boolean response = user.isApplicant();
 
             Assertions.assertFalse(response);
         }
@@ -46,7 +46,7 @@ public class UserTest {
         void shouldReturnFalseWhenUserIsNotAnApplicant() {
             final User user = User.builder().build();
 
-            final boolean response = user.isAnApplicant();
+            final boolean response = user.isApplicant();
 
             Assertions.assertFalse(response);
         }
@@ -59,7 +59,7 @@ public class UserTest {
             );
             final User user = User.builder().roles(roles).build();
 
-            final boolean response = user.isAnApplicant();
+            final boolean response = user.isApplicant();
 
             Assertions.assertTrue(response);
         }
@@ -76,7 +76,7 @@ public class UserTest {
             );
             final User user = User.builder().roles(roles).build();
 
-            final boolean response = user.isAnAdmin();
+            final boolean response = user.isAdmin();
 
             Assertions.assertTrue(response);
         }
@@ -91,7 +91,7 @@ public class UserTest {
             );
             final User user = User.builder().roles(roles).build();
 
-            final boolean response = user.isAnAdmin();
+            final boolean response = user.isAdmin();
 
             Assertions.assertTrue(response);
         }
@@ -104,7 +104,7 @@ public class UserTest {
             );
             final User user = User.builder().roles(roles).build();
 
-            final boolean response = user.isAnAdmin();
+            final boolean response = user.isAdmin();
 
             Assertions.assertFalse(response);
         }
@@ -121,7 +121,7 @@ public class UserTest {
             );
             final User user = User.builder().roles(roles).build();
 
-            final boolean response = user.isASuperAdmin();
+            final boolean response = user.isSuperAdmin();
 
             Assertions.assertFalse(response);
         }
@@ -136,7 +136,7 @@ public class UserTest {
             );
             final User user = User.builder().roles(roles).build();
 
-            final boolean response = user.isASuperAdmin();
+            final boolean response = user.isSuperAdmin();
 
             Assertions.assertTrue(response);
         }
@@ -149,7 +149,7 @@ public class UserTest {
             );
             final User user = User.builder().roles(roles).build();
 
-            final boolean response = user.isASuperAdmin();
+            final boolean response = user.isSuperAdmin();
 
             Assertions.assertFalse(response);
         }

--- a/src/test/java/gov/cabinetofice/gapuserservice/model/UserTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/model/UserTest.java
@@ -1,0 +1,199 @@
+package gov.cabinetofice.gapuserservice.model;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+public class UserTest {
+
+    @Nested
+    class isUserApplicant {
+        @Test
+        void shouldReturnFalseWhenUserIsAdmin() {
+            final List<Role> roles = List.of(
+                    Role.builder().name(RoleEnum.ADMIN).build(),
+                    Role.builder().name(RoleEnum.APPLICANT).build(),
+                    Role.builder().name(RoleEnum.FIND).build()
+            );
+            final User user = User.builder().roles(roles).build();
+
+            final boolean response = user.isAnApplicant();
+
+            Assertions.assertFalse(response);
+        }
+
+        @Test
+        void shouldReturnFalseWhenUserIsSuperAdmin() {
+            final List<Role> roles = List.of(
+                    Role.builder().name(RoleEnum.SUPER_ADMIN).build(),
+                    Role.builder().name(RoleEnum.ADMIN).build(),
+                    Role.builder().name(RoleEnum.APPLICANT).build(),
+                    Role.builder().name(RoleEnum.FIND).build()
+            );
+            final User user = User.builder().roles(roles).build();
+
+            final boolean response = user.isAnApplicant();
+
+            Assertions.assertFalse(response);
+        }
+
+        @Test
+        void shouldReturnFalseWhenUserIsNotAnApplicant() {
+            final User user = User.builder().build();
+
+            final boolean response = user.isAnApplicant();
+
+            Assertions.assertFalse(response);
+        }
+
+        @Test
+        void shouldReturnTrueWhenUserIsApplicant() {
+            final List<Role> roles = List.of(
+                    Role.builder().name(RoleEnum.APPLICANT).build(),
+                    Role.builder().name(RoleEnum.FIND).build()
+            );
+            final User user = User.builder().roles(roles).build();
+
+            final boolean response = user.isAnApplicant();
+
+            Assertions.assertTrue(response);
+        }
+    }
+
+    @Nested
+    class isUserAdmin {
+        @Test
+        void shouldReturnTrueWhenUserIsAdmin() {
+            final List<Role> roles = List.of(
+                    Role.builder().name(RoleEnum.ADMIN).build(),
+                    Role.builder().name(RoleEnum.APPLICANT).build(),
+                    Role.builder().name(RoleEnum.FIND).build()
+            );
+            final User user = User.builder().roles(roles).build();
+
+            final boolean response = user.isAnAdmin();
+
+            Assertions.assertTrue(response);
+        }
+
+        @Test
+        void shouldReturnTrueWhenUserIsSuperAdmin() {
+            final List<Role> roles = List.of(
+                    Role.builder().name(RoleEnum.SUPER_ADMIN).build(),
+                    Role.builder().name(RoleEnum.ADMIN).build(),
+                    Role.builder().name(RoleEnum.APPLICANT).build(),
+                    Role.builder().name(RoleEnum.FIND).build()
+            );
+            final User user = User.builder().roles(roles).build();
+
+            final boolean response = user.isAnAdmin();
+
+            Assertions.assertTrue(response);
+        }
+
+        @Test
+        void shouldReturnFalseWhenUserIsAnApplicant() {
+            final List<Role> roles = List.of(
+                    Role.builder().name(RoleEnum.APPLICANT).build(),
+                    Role.builder().name(RoleEnum.FIND).build()
+            );
+            final User user = User.builder().roles(roles).build();
+
+            final boolean response = user.isAnAdmin();
+
+            Assertions.assertFalse(response);
+        }
+    }
+
+    @Nested
+    class isUserSuperAdmin {
+        @Test
+        void shouldReturnFalseWhenUserIsAdmin() {
+            final List<Role> roles = List.of(
+                    Role.builder().name(RoleEnum.ADMIN).build(),
+                    Role.builder().name(RoleEnum.APPLICANT).build(),
+                    Role.builder().name(RoleEnum.FIND).build()
+            );
+            final User user = User.builder().roles(roles).build();
+
+            final boolean response = user.isASuperAdmin();
+
+            Assertions.assertFalse(response);
+        }
+
+        @Test
+        void shouldReturnTrueWhenUserIsSuperAdmin() {
+            final List<Role> roles = List.of(
+                    Role.builder().name(RoleEnum.SUPER_ADMIN).build(),
+                    Role.builder().name(RoleEnum.ADMIN).build(),
+                    Role.builder().name(RoleEnum.APPLICANT).build(),
+                    Role.builder().name(RoleEnum.FIND).build()
+            );
+            final User user = User.builder().roles(roles).build();
+
+            final boolean response = user.isASuperAdmin();
+
+            Assertions.assertTrue(response);
+        }
+
+        @Test
+        void shouldReturnFalseWhenUserIsAnApplicant() {
+            final List<Role> roles = List.of(
+                    Role.builder().name(RoleEnum.APPLICANT).build(),
+                    Role.builder().name(RoleEnum.FIND).build()
+            );
+            final User user = User.builder().roles(roles).build();
+
+            final boolean response = user.isASuperAdmin();
+
+            Assertions.assertFalse(response);
+        }
+    }
+
+    @Nested
+    class hasEmail {
+        @Test
+        void shouldReturnTrueWhenUserHasEmail() {
+            final User user = User.builder().email("").build();
+
+            final boolean response = user.hasEmail();
+
+            Assertions.assertTrue(response);
+        }
+
+        @Test
+        void shouldReturnFalseWhenUserDoesNotHaveEmail() {
+            final User user = User.builder().build();
+
+            final boolean response = user.hasEmail();
+
+            Assertions.assertFalse(response);
+        }
+    }
+
+    @Nested
+    class hasSub {
+        @Test
+        void shouldReturnTrueWhenUserHasSub() {
+            final User user = User.builder().sub("").build();
+
+            final boolean response = user.hasSub();
+
+            Assertions.assertTrue(response);
+        }
+
+        @Test
+        void shouldReturnFalseWhenUserDoesNotHaveSub() {
+            final User user = User.builder().build();
+
+            final boolean response = user.hasSub();
+
+            Assertions.assertFalse(response);
+        }
+    }
+}

--- a/src/test/java/gov/cabinetofice/gapuserservice/service/OneLoginServiceTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/service/OneLoginServiceTest.java
@@ -186,60 +186,6 @@ public class OneLoginServiceTest {
     }
 
     @Test
-    void shouldReturnDoesUserExist_Email() {
-        when(userRepository.existsByEmail(anyString())).thenReturn(true);
-
-        final boolean result = oneLoginService.doesUserExistByEmail("");
-
-        Assertions.assertTrue(result);
-    }
-
-    @Test
-    void shouldReturnDoesUserExist_Sub() {
-        when(userRepository.existsBySub(anyString())).thenReturn(true);
-
-        final boolean result = oneLoginService.doesUserExistBySub("");
-
-        Assertions.assertTrue(result);
-    }
-
-    @Test
-    void shouldReturnUsersRoles_Email() {
-        final List<Role> roles = List.of(
-                Role.builder().name(RoleEnum.APPLICANT).build(),
-                Role.builder().name(RoleEnum.FIND).build(),
-                Role.builder().name(RoleEnum.ADMIN).build(),
-                Role.builder().name(RoleEnum.SUPER_ADMIN).build()
-        );
-
-        when(roleRepository.findByUsers_Email(anyString())).thenReturn(roles);
-
-        final List<RoleEnum> result = oneLoginService.getUsersRolesByEmail("");
-
-        Assertions.assertEquals(4, result.size());
-        Assertions.assertEquals(RoleEnum.APPLICANT, result.get(0));
-        Assertions.assertEquals(RoleEnum.FIND, result.get(1));
-        Assertions.assertEquals(RoleEnum.ADMIN, result.get(2));
-        Assertions.assertEquals(RoleEnum.SUPER_ADMIN, result.get(3));
-    }
-
-    @Test
-    void shouldReturnUsersRoles_Sub() {
-        final List<Role> roles = List.of(
-                Role.builder().name(RoleEnum.APPLICANT).build(),
-                Role.builder().name(RoleEnum.FIND).build()
-        );
-
-        when(roleRepository.findByUsers_Sub(anyString())).thenReturn(roles);
-
-        final List<RoleEnum> result = oneLoginService.getUsersRolesBySub("");
-
-        Assertions.assertEquals(2, result.size());
-        Assertions.assertEquals(RoleEnum.APPLICANT, result.get(0));
-        Assertions.assertEquals(RoleEnum.FIND, result.get(1));
-    }
-
-    @Test
     void shouldReturnNewUserRoles() {
         final List<RoleEnum> result = oneLoginService.getNewUserRoles();
 
@@ -249,116 +195,16 @@ public class OneLoginServiceTest {
     }
 
     @Nested
-    class isUserApplicant {
-        @Test
-        void shouldReturnFalseWhenUserIsAdmin() {
-            final List<RoleEnum> roles = List.of(RoleEnum.APPLICANT, RoleEnum.FIND, RoleEnum.ADMIN);
-
-            final boolean response = oneLoginService.isUserAnApplicant(roles);
-
-            Assertions.assertFalse(response);
-        }
-
-        @Test
-        void shouldReturnFalseWhenUserIsSuperAdmin() {
-            final List<RoleEnum> roles = List.of(RoleEnum.APPLICANT, RoleEnum.FIND, RoleEnum.SUPER_ADMIN, RoleEnum.ADMIN);
-
-            final boolean response = oneLoginService.isUserAnApplicant(roles);
-
-            Assertions.assertFalse(response);
-        }
-
-        @Test
-        void shouldReturnFalseWhenUserIsNotAnApplicant() {
-            final List<RoleEnum> roles = new ArrayList<>();
-
-            final boolean response = oneLoginService.isUserAnApplicant(roles);
-
-            Assertions.assertFalse(response);
-        }
-
-        @Test
-        void shouldReturnTrueWhenUserIsApplicant() {
-            final List<RoleEnum> roles = List.of(RoleEnum.APPLICANT, RoleEnum.FIND);
-
-            final boolean response = oneLoginService.isUserAnApplicant(roles);
-
-            Assertions.assertTrue(response);
-        }
-    }
-
-    @Nested
-    class isUserAdmin {
-        @Test
-        void shouldReturnTrueWhenUserIsAdmin() {
-            final List<RoleEnum> roles = List.of(RoleEnum.APPLICANT, RoleEnum.FIND, RoleEnum.ADMIN);
-
-            final boolean response = oneLoginService.isUserAnAdmin(roles);
-
-            Assertions.assertTrue(response);
-        }
-
-        @Test
-        void shouldReturnTrueWhenUserIsSuperAdmin() {
-            final List<RoleEnum> roles = List.of(RoleEnum.APPLICANT, RoleEnum.FIND, RoleEnum.SUPER_ADMIN, RoleEnum.ADMIN);
-
-            final boolean response = oneLoginService.isUserAnAdmin(roles);
-
-            Assertions.assertTrue(response);
-        }
-
-        @Test
-        void shouldReturnFalseWhenUserIsAnApplicant() {
-            final List<RoleEnum> roles = List.of(RoleEnum.APPLICANT, RoleEnum.FIND);
-
-            final boolean response = oneLoginService.isUserAnAdmin(roles);
-
-            Assertions.assertFalse(response);
-        }
-    }
-
-    @Nested
-    class isUserSuperAdmin {
-        @Test
-        void shouldReturnFalseWhenUserIsAdmin() {
-            final List<RoleEnum> roles = List.of(RoleEnum.APPLICANT, RoleEnum.FIND, RoleEnum.ADMIN);
-
-            final boolean response = oneLoginService.isUserASuperAdmin(roles);
-
-            Assertions.assertFalse(response);
-        }
-
-        @Test
-        void shouldReturnTrueWhenUserIsSuperAdmin() {
-            final List<RoleEnum> roles = List.of(RoleEnum.APPLICANT, RoleEnum.FIND, RoleEnum.SUPER_ADMIN, RoleEnum.ADMIN);
-
-            final boolean response = oneLoginService.isUserASuperAdmin(roles);
-
-            Assertions.assertTrue(response);
-        }
-
-        @Test
-        void shouldReturnFalseWhenUserIsAnApplicant() {
-            final List<RoleEnum> roles = List.of(RoleEnum.APPLICANT, RoleEnum.FIND);
-
-            final boolean response = oneLoginService.isUserASuperAdmin(roles);
-
-            Assertions.assertFalse(response);
-        }
-    }
-
-    @Nested
     class createUser {
         @Test
-        void shouldReturnUserRolesWhenUserIsCreated() {
-            when(roleRepository.findByName(RoleEnum.APPLICANT)).thenReturn(Optional.of(Role.builder().name(RoleEnum.APPLICANT).build()));
-            when(roleRepository.findByName(RoleEnum.FIND)).thenReturn(Optional.of(Role.builder().name(RoleEnum.FIND).build()));
+        void shouldReturnSavedUser() {
+            when(roleRepository.findByName(any())).thenReturn(Optional.of(Role.builder().name(RoleEnum.APPLICANT).build()));
+            when(userRepository.save(any())).thenReturn(User.builder().roles(List.of(Role.builder().name(RoleEnum.APPLICANT).build())).build());
 
-            final List<RoleEnum> result = oneLoginService.createUser("", "");
+            final User result = oneLoginService.createUser("", "");
 
-            Assertions.assertEquals(2, result.size());
-            Assertions.assertEquals(RoleEnum.APPLICANT, result.get(0));
-            Assertions.assertEquals(RoleEnum.FIND, result.get(1));
+            Assertions.assertEquals(1, result.getRoles().size());
+            Assertions.assertEquals(RoleEnum.APPLICANT, result.getRoles().get(0).getName());
         }
 
         @Test

--- a/src/test/java/gov/cabinetofice/gapuserservice/service/OneLoginServiceTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/service/OneLoginServiceTest.java
@@ -4,6 +4,7 @@ import gov.cabinetofice.gapuserservice.dto.OneLoginUserInfoDto;
 import gov.cabinetofice.gapuserservice.exceptions.AuthenticationException;
 import gov.cabinetofice.gapuserservice.exceptions.InvalidRequestException;
 import gov.cabinetofice.gapuserservice.exceptions.PrivateKeyParsingException;
+import gov.cabinetofice.gapuserservice.model.RoleEnum;
 import gov.cabinetofice.gapuserservice.util.RestUtils;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -21,9 +22,7 @@ import java.io.IOException;
 import java.security.*;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import static io.jsonwebtoken.impl.crypto.RsaProvider.generateKeyPair;
 import static org.mockito.Mockito.mockStatic;
@@ -206,22 +205,46 @@ public class OneLoginServiceTest {
     class isUserApplicant {
         @Test
         void shouldReturnFalseWhenUserIsAdmin() {
+            final List<RoleEnum> roles = new ArrayList<>();
+            roles.add(RoleEnum.ADMIN);
+            roles.add(RoleEnum.APPLICANT);
+            roles.add(RoleEnum.FIND);
 
+            final boolean response = oneLoginService.isUserAnApplicant(roles);
+
+            Assertions.assertFalse(response);
         }
 
         @Test
         void shouldReturnFalseWhenUserIsSuperAdmin() {
+            final List<RoleEnum> roles = new ArrayList<>();
+            roles.add(RoleEnum.SUPER_ADMIN);
+            roles.add(RoleEnum.APPLICANT);
+            roles.add(RoleEnum.FIND);
 
+            final boolean response = oneLoginService.isUserAnApplicant(roles);
+
+            Assertions.assertFalse(response);
         }
 
         @Test
         void shouldReturnFalseWhenUserIsNotAnApplicant() {
+            final List<RoleEnum> roles = new ArrayList<>();
 
+            final boolean response = oneLoginService.isUserAnApplicant(roles);
+
+            Assertions.assertFalse(response);
         }
 
         @Test
         void shouldReturnTrueWhenUserIsApplicant() {
+            final List<RoleEnum> roles = new ArrayList<>();
+            roles.add(RoleEnum.APPLICANT);
+            roles.add(RoleEnum.FIND);
 
+            final boolean response = oneLoginService.isUserAnApplicant(roles);
+
+            Assertions.assertTrue(response);
         }
     }
 
@@ -229,17 +252,38 @@ public class OneLoginServiceTest {
     class isUserAdmin {
         @Test
         void shouldReturnTrueWhenUserIsAdmin() {
+            final List<RoleEnum> roles = new ArrayList<>();
+            roles.add(RoleEnum.ADMIN);
+            roles.add(RoleEnum.APPLICANT);
+            roles.add(RoleEnum.FIND);
 
+            final boolean response = oneLoginService.isUserAnAdmin(roles);
+
+            Assertions.assertTrue(response);
         }
 
         @Test
         void shouldReturnTrueWhenUserIsSuperAdmin() {
+            final List<RoleEnum> roles = new ArrayList<>();
+            roles.add(RoleEnum.SUPER_ADMIN);
+            roles.add(RoleEnum.ADMIN);
+            roles.add(RoleEnum.APPLICANT);
+            roles.add(RoleEnum.FIND);
 
+            final boolean response = oneLoginService.isUserAnAdmin(roles);
+
+            Assertions.assertTrue(response);
         }
 
         @Test
         void shouldReturnFalseWhenUserIsAnApplicant() {
+            final List<RoleEnum> roles = new ArrayList<>();
+            roles.add(RoleEnum.APPLICANT);
+            roles.add(RoleEnum.FIND);
 
+            final boolean response = oneLoginService.isUserAnAdmin(roles);
+
+            Assertions.assertFalse(response);
         }
     }
 
@@ -247,17 +291,38 @@ public class OneLoginServiceTest {
     class isUserSuperAdmin {
         @Test
         void shouldReturnFalseWhenUserIsAdmin() {
+            final List<RoleEnum> roles = new ArrayList<>();
+            roles.add(RoleEnum.ADMIN);
+            roles.add(RoleEnum.APPLICANT);
+            roles.add(RoleEnum.FIND);
 
+            final boolean response = oneLoginService.isUserASuperAdmin(roles);
+
+            Assertions.assertFalse(response);
         }
 
         @Test
         void shouldReturnTrueWhenUserIsSuperAdmin() {
+            final List<RoleEnum> roles = new ArrayList<>();
+            roles.add(RoleEnum.SUPER_ADMIN);
+            roles.add(RoleEnum.ADMIN);
+            roles.add(RoleEnum.APPLICANT);
+            roles.add(RoleEnum.FIND);
 
+            final boolean response = oneLoginService.isUserASuperAdmin(roles);
+
+            Assertions.assertTrue(response);
         }
 
         @Test
         void shouldReturnFalseWhenUserIsAnApplicant() {
+            final List<RoleEnum> roles = new ArrayList<>();
+            roles.add(RoleEnum.APPLICANT);
+            roles.add(RoleEnum.FIND);
 
+            final boolean response = oneLoginService.isUserASuperAdmin(roles);
+
+            Assertions.assertFalse(response);
         }
     }
 

--- a/src/test/java/gov/cabinetofice/gapuserservice/service/OneLoginServiceTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/service/OneLoginServiceTest.java
@@ -1,5 +1,6 @@
 package gov.cabinetofice.gapuserservice.service;
 
+import gov.cabinetofice.gapuserservice.dto.OneLoginUserInfoDto;
 import gov.cabinetofice.gapuserservice.exceptions.AuthenticationException;
 import gov.cabinetofice.gapuserservice.exceptions.InvalidRequestException;
 import gov.cabinetofice.gapuserservice.exceptions.PrivateKeyParsingException;
@@ -79,7 +80,6 @@ public class OneLoginServiceTest {
 
     @Test
     void shouldThrowPrivateKeyParsingExceptionWhenKeyIsInvalid() {
-
         ReflectionTestUtils.setField(oneLoginService, "privateKey", "invalidKey");
 
         Assertions.assertThrows(PrivateKeyParsingException.class, () -> oneLoginService.createOneLoginJwt());
@@ -88,8 +88,6 @@ public class OneLoginServiceTest {
 
     @Test
     void shouldReturnValidAuthToken() throws IOException, JSONException {
-
-
         String requestBody = "grant_type=" + GRANT_TYPE +
                 "&code=" + "dummyCode" +
                 "&redirect_uri=" + DUMMY_BASE_URL + "/redirect" +
@@ -104,30 +102,30 @@ public class OneLoginServiceTest {
         String result = oneLoginService.getAuthToken("dummyJwt", "dummyCode");
 
         Assertions.assertEquals("dummyToken", result);
-
     }
 
     @Test
     void shouldReturnUserInfo() throws IOException, JSONException {
-
-        String expectedResponse = "{\"sub\":\"urn:fdc:gov.uk:2022:jhkdasy7dal7dadhadasdas\"" +
+        String jsonResponse = "{\"sub\":\"urn:fdc:gov.uk:2022:jhkdasy7dal7dadhadasdas\"" +
                 ",\"email_verified\":\"true\",\"email\":\"test.user@email.com\"}";
+        OneLoginUserInfoDto expectedResponse = OneLoginUserInfoDto.builder()
+                .sub("urn:fdc:gov.uk:2022:jhkdasy7dal7dadhadasdas")
+                .email("test.user@email.com")
+                .build();
 
        Map<String, String> headers = new HashMap<>();
         headers.put(HttpHeaders.AUTHORIZATION, "Bearer " + "accessToken");
 
         when(RestUtils.getRequestWithHeaders(DUMMY_BASE_URL + "/userinfo", headers))
-                .thenReturn(new JSONObject(expectedResponse));
+                .thenReturn(new JSONObject(jsonResponse));
 
-        String result = oneLoginService.getUserInfo("accessToken");
+        OneLoginUserInfoDto result = oneLoginService.getUserInfo("accessToken");
 
         Assertions.assertEquals(expectedResponse, result);
-
     }
 
     @Test
     void shouldThrowAuthenticationExceptionWhenRequestFails() throws IOException {
-
         Map<String, String> headers = new HashMap<>();
         headers.put(HttpHeaders.AUTHORIZATION, "Bearer " + "accessToken");
 
@@ -137,7 +135,6 @@ public class OneLoginServiceTest {
 
         Assertions.assertThrows(AuthenticationException.class, () -> oneLoginService
                 .getUserInfo("accessToken"));
-
     }
 
 
@@ -160,7 +157,6 @@ public class OneLoginServiceTest {
 
         Assertions.assertThrows(AuthenticationException.class, () -> oneLoginService
                 .getAuthToken("dummyJwt", "dummyCode"));
-
     }
 
     @Test
@@ -179,9 +175,122 @@ public class OneLoginServiceTest {
 
         Assertions.assertThrows(InvalidRequestException.class, () -> oneLoginService
                 .getAuthToken("dummyJwt", "dummyCode"));
+    }
+
+    @Test
+    void shouldReturnDoesUserExist_Email() {
 
     }
 
+    @Test
+    void shouldReturnDoesUserExist_Sub() {
+
+    }
+
+    @Test
+    void shouldReturnUsersRoles_Email() {
+
+    }
+
+    @Test
+    void shouldReturnUsersRoles_Sub() {
+
+    }
+
+    @Test
+    void shouldReturnNewUserRoles() {
+
+    }
+
+    @Nested
+    class isUserApplicant {
+        @Test
+        void shouldReturnFalseWhenUserIsAdmin() {
+
+        }
+
+        @Test
+        void shouldReturnFalseWhenUserIsSuperAdmin() {
+
+        }
+
+        @Test
+        void shouldReturnFalseWhenUserIsNotAnApplicant() {
+
+        }
+
+        @Test
+        void shouldReturnTrueWhenUserIsApplicant() {
+
+        }
+    }
+
+    @Nested
+    class isUserAdmin {
+        @Test
+        void shouldReturnTrueWhenUserIsAdmin() {
+
+        }
+
+        @Test
+        void shouldReturnTrueWhenUserIsSuperAdmin() {
+
+        }
+
+        @Test
+        void shouldReturnFalseWhenUserIsAnApplicant() {
+
+        }
+    }
+
+    @Nested
+    class isUserSuperAdmin {
+        @Test
+        void shouldReturnFalseWhenUserIsAdmin() {
+
+        }
+
+        @Test
+        void shouldReturnTrueWhenUserIsSuperAdmin() {
+
+        }
+
+        @Test
+        void shouldReturnFalseWhenUserIsAnApplicant() {
+
+        }
+    }
+
+    @Nested
+    class createUser {
+        @Test
+        void shouldReturnUserRolesWhenUserIsCreated() {
+
+        }
+
+        @Test
+        void shouldSaveUserWithSubAndEmailWhenUserIsCreated() {
+
+        }
+
+        @Test
+        void shouldThrowExceptionWhenRoleDoesNotExist() {
+
+        }
+    }
+
+    @Nested
+    class addSubToUser {
+        @Test
+        void shouldSaveUserWithSubWhenUserExists() {
+
+        }
+
+        @Test
+        void shouldThrowExceptionWhenUserDoesNotExist() {
+
+        }
+    }
 
     private Claims getClaims(String jwtToken) throws NoSuchAlgorithmException, InvalidKeySpecException {
 

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
@@ -1,15 +1,10 @@
 package gov.cabinetofice.gapuserservice.web;
 
 import gov.cabinetofice.gapuserservice.service.OneLoginService;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.ResponseEntity;
-
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class LoginControllerV2Test {
@@ -20,22 +15,5 @@ class LoginControllerV2Test {
     @Mock
     private OneLoginService oneLoginService;
 
-
-    @Test
-    void shouldReturnUserInfoTest() {
-
-        when(oneLoginService.createOneLoginJwt()).thenReturn("test-jwt");
-        when(oneLoginService.getAuthToken("test-jwt", "1234")).thenReturn("test-auth-token");
-        when(oneLoginService.getUserInfo("test-auth-token")).thenReturn("test-user-info");
-
-        ResponseEntity<String> result = loginController.redirect("1234");
-
-        verify(oneLoginService, times(1)).createOneLoginJwt();
-        verify(oneLoginService, times(1)).getAuthToken("test-jwt", "1234");
-        verify(oneLoginService, times(1)).getUserInfo("test-auth-token");
-
-        Assertions.assertEquals("test-user-info", result.getBody());
-
-    }
 
 }

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
@@ -1,19 +1,143 @@
 package gov.cabinetofice.gapuserservice.web;
 
+import gov.cabinetofice.gapuserservice.config.ApplicationConfigProperties;
 import gov.cabinetofice.gapuserservice.service.OneLoginService;
+import gov.cabinetofice.gapuserservice.service.jwt.impl.CustomJwtServiceImpl;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.servlet.view.RedirectView;
+import org.springframework.web.util.WebUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class LoginControllerV2Test {
 
-    @InjectMocks
     private LoginControllerV2 loginController;
 
     @Mock
     private OneLoginService oneLoginService;
 
+    @Mock
+    private ApplicationConfigProperties configProperties;
 
+    @Mock
+    private CustomJwtServiceImpl customJwtService;
+
+    private static MockedStatic<WebUtils> mockedStatic;
+
+    @BeforeEach
+    void setUp() {
+        mockedStatic = mockStatic(WebUtils.class);
+
+        configProperties = ApplicationConfigProperties.builder()
+                .defaultRedirectUrl("https://www.find-government-grants.service.gov.uk/")
+                .build();
+
+        loginController = new LoginControllerV2(oneLoginService, customJwtService, configProperties);
+    }
+
+    @AfterEach
+    public void close() {
+        mockedStatic.close();
+    }
+
+    @Nested
+    class login {
+        @Test
+        void shouldRedirectToOneLogin_IfTokenIsNull() {
+            final Optional<String> redirectUrl = Optional.of("https://www.find-government-grants.service.gov.uk/");
+            final HttpServletResponse response = Mockito.spy(new MockHttpServletResponse());
+            final MockHttpServletRequest request = new MockHttpServletRequest();
+
+            ReflectionTestUtils.setField(loginController, "oneLoginBaseUrl", "oneLoginBaseUrl");
+
+            final RedirectView methodResponse = loginController.login(redirectUrl, request, response);
+
+            final Cookie redirectUrlCookie = new Cookie(LoginController.REDIRECT_URL_COOKIE, redirectUrl.get());
+            redirectUrlCookie.setSecure(true);
+            redirectUrlCookie.setHttpOnly(true);
+            redirectUrlCookie.setPath("/");
+
+            verify(response).addCookie(redirectUrlCookie);
+            assertThat(methodResponse.getUrl()).isEqualTo("oneLoginBaseUrl");
+        }
+
+        @Test
+        void shouldReturnRedirectUrl_IfOneIsProvided_AndTokenIsValid() {
+            final String customToken = "a-custom-valid-token";
+            final Optional<String> redirectUrl = Optional.of("https://www.find-government-grants.service.gov.uk/");
+            final HttpServletResponse response = Mockito.spy(new MockHttpServletResponse());
+            final MockHttpServletRequest request = new MockHttpServletRequest();
+
+            ReflectionTestUtils.setField(loginController, "userServiceCookieName", "userServiceCookieName");
+            mockedStatic.when(() -> WebUtils.getCookie(request, "userServiceCookieName"))
+                    .thenReturn(new Cookie(LoginController.REDIRECT_URL_COOKIE, customToken));
+            when(customJwtService.isTokenValid(customToken))
+                    .thenReturn(true);
+
+            final RedirectView methodResponse = loginController.login(redirectUrl, request, response);
+
+            verify(customJwtService, times(0)).generateToken(any());
+            assertThat(methodResponse.getUrl()).isEqualTo(redirectUrl.get());
+        }
+
+        @Test
+        void shouldReturnDefaultRedirectUrl_IfRedirectUrlNotProvided_AndTokenIsValid() {
+            final String customToken = "a-custom-valid-token";
+            final Optional<String> redirectUrl = Optional.empty();
+            final HttpServletResponse response = Mockito.spy(new MockHttpServletResponse());
+            final MockHttpServletRequest request = new MockHttpServletRequest();
+
+            ReflectionTestUtils.setField(loginController, "userServiceCookieName", "userServiceCookieName");
+            mockedStatic.when(() -> WebUtils.getCookie(request, "userServiceCookieName"))
+                    .thenReturn(new Cookie(LoginController.REDIRECT_URL_COOKIE, customToken));
+            when(customJwtService.isTokenValid(customToken))
+                    .thenReturn(true);
+
+            final RedirectView methodResponse = loginController.login(redirectUrl, request, response);
+
+            verify(customJwtService, times(0)).generateToken(any());
+            assertThat(methodResponse.getUrl()).isEqualTo(configProperties.getDefaultRedirectUrl());
+        }
+    }
+
+    @Nested
+    class redirectAfterLogin {
+
+        @Test
+        void shouldCreateNewUser_WhenNoUserFound() {
+
+        }
+
+        @Test
+        void shouldDoNothing_WhenUserFoundWithSub() {
+
+        }
+
+        @Test
+        void shouldUpdateUser_WhenUserFoundWithoutSub_AndIsAdmin() {
+
+        }
+
+        @Test
+        void shouldGoToMigrateDataPage_WhenUserFoundWithoutSub_AndIsAnApplicant() {
+
+        }
+    }
 }

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
@@ -1,14 +1,15 @@
 package gov.cabinetofice.gapuserservice.web;
 
 import gov.cabinetofice.gapuserservice.config.ApplicationConfigProperties;
+import gov.cabinetofice.gapuserservice.dto.OneLoginUserInfoDto;
+import gov.cabinetofice.gapuserservice.model.Role;
+import gov.cabinetofice.gapuserservice.model.RoleEnum;
+import gov.cabinetofice.gapuserservice.model.User;
 import gov.cabinetofice.gapuserservice.service.OneLoginService;
 import gov.cabinetofice.gapuserservice.service.jwt.impl.CustomJwtServiceImpl;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -20,6 +21,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.view.RedirectView;
 import org.springframework.web.util.WebUtils;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -50,6 +52,9 @@ class LoginControllerV2Test {
                 .build();
 
         loginController = new LoginControllerV2(oneLoginService, customJwtService, configProperties);
+        ReflectionTestUtils.setField(loginController, "oneLoginBaseUrl", "oneLoginBaseUrl");
+        ReflectionTestUtils.setField(loginController, "userServiceCookieName", "userServiceCookieName");
+        ReflectionTestUtils.setField(loginController, "adminBaseUrl", "adminBaseUrl");
     }
 
     @AfterEach
@@ -64,8 +69,6 @@ class LoginControllerV2Test {
             final Optional<String> redirectUrl = Optional.of("https://www.find-government-grants.service.gov.uk/");
             final HttpServletResponse response = Mockito.spy(new MockHttpServletResponse());
             final MockHttpServletRequest request = new MockHttpServletRequest();
-
-            ReflectionTestUtils.setField(loginController, "oneLoginBaseUrl", "oneLoginBaseUrl");
 
             final RedirectView methodResponse = loginController.login(redirectUrl, request, response);
 
@@ -85,7 +88,6 @@ class LoginControllerV2Test {
             final HttpServletResponse response = Mockito.spy(new MockHttpServletResponse());
             final MockHttpServletRequest request = new MockHttpServletRequest();
 
-            ReflectionTestUtils.setField(loginController, "userServiceCookieName", "userServiceCookieName");
             mockedStatic.when(() -> WebUtils.getCookie(request, "userServiceCookieName"))
                     .thenReturn(new Cookie(LoginController.REDIRECT_URL_COOKIE, customToken));
             when(customJwtService.isTokenValid(customToken))
@@ -104,12 +106,10 @@ class LoginControllerV2Test {
             final HttpServletResponse response = Mockito.spy(new MockHttpServletResponse());
             final MockHttpServletRequest request = new MockHttpServletRequest();
 
-            ReflectionTestUtils.setField(loginController, "userServiceCookieName", "userServiceCookieName");
             mockedStatic.when(() -> WebUtils.getCookie(request, "userServiceCookieName"))
                     .thenReturn(new Cookie(LoginController.REDIRECT_URL_COOKIE, customToken));
             when(customJwtService.isTokenValid(customToken))
                     .thenReturn(true);
-
             final RedirectView methodResponse = loginController.login(redirectUrl, request, response);
 
             verify(customJwtService, times(0)).generateToken(any());
@@ -120,24 +120,117 @@ class LoginControllerV2Test {
     @Nested
     class redirectAfterLogin {
 
+        final static Cookie customJwtCookie = new Cookie("userServiceCookieName", "a-custom-valid-token");
+
+        @BeforeAll
+        static void beforeAll() {
+            customJwtCookie.setSecure(true);
+            customJwtCookie.setHttpOnly(true);
+            customJwtCookie.setPath("/");
+        }
+
+        @BeforeEach
+        void beforeEach() {
+            when(oneLoginService.getUserInfo(null))
+                    .thenReturn(OneLoginUserInfoDto.builder()
+                            .sub("sub")
+                            .email("email")
+                            .build());
+            when(customJwtService.generateToken(any()))
+                    .thenReturn("a-custom-valid-token");
+        }
+
         @Test
         void shouldCreateNewUser_WhenNoUserFound() {
+            final HttpServletResponse response = Mockito.spy(new MockHttpServletResponse());
+            final Optional<String> redirectUrl = Optional.of("redirectUrl");
 
+            when(oneLoginService.getUser("email", "sub"))
+                    .thenReturn(Optional.empty());
+            when(oneLoginService.createUser("sub", "email"))
+                    .thenReturn(User.builder().build());
+
+            final RedirectView methodResponse = loginController.redirectAfterLogin(redirectUrl, response, "a-custom-valid-token");
+
+            verify(response).addCookie(customJwtCookie);
+            verify(oneLoginService).createUser("sub", "email");
+            assertThat(methodResponse.getUrl()).isEqualTo(redirectUrl.get());
         }
 
         @Test
         void shouldDoNothing_WhenUserFoundWithSub() {
+            final HttpServletResponse response = Mockito.spy(new MockHttpServletResponse());
+            final Optional<String> redirectUrl = Optional.of("redirectUrl");
+            final User user = User.builder().sub("sub").email("email").build();
 
+            when(oneLoginService.getUser("email", "sub"))
+                    .thenReturn(Optional.of(user));
+
+            final RedirectView methodResponse = loginController.redirectAfterLogin(redirectUrl, response, "a-custom-valid-token");
+
+            verify(response).addCookie(customJwtCookie);
+            verify(oneLoginService, times(0)).createUser(anyString(), anyString());
+            verify(oneLoginService, times(0)).addSubToUser(anyString(), anyString());
+            assertThat(methodResponse.getUrl()).isEqualTo(redirectUrl.get());
         }
 
         @Test
         void shouldUpdateUser_WhenUserFoundWithoutSub_AndIsAdmin() {
+            final HttpServletResponse response = Mockito.spy(new MockHttpServletResponse());
+            final Optional<String> redirectUrl = Optional.of("redirectUrl");
+            final User user = User.builder().email("email").roles(List.of(
+                    Role.builder().name(RoleEnum.ADMIN).build(),
+                    Role.builder().name(RoleEnum.APPLICANT).build(),
+                    Role.builder().name(RoleEnum.FIND).build()
+            )).build();
 
+            when(oneLoginService.getUser("email", "sub"))
+                    .thenReturn(Optional.of(user));
+
+            final RedirectView methodResponse = loginController.redirectAfterLogin(redirectUrl, response, "a-custom-valid-token");
+
+            verify(response).addCookie(customJwtCookie);
+            verify(oneLoginService).addSubToUser("sub", "email");
+            assertThat(methodResponse.getUrl()).isEqualTo("adminBaseUrl/dashboard");
+        }
+
+        @Test
+        void shouldUpdateUser_WhenUserFoundWithoutSub_AndIsSuperAdmin() {
+            final HttpServletResponse response = Mockito.spy(new MockHttpServletResponse());
+            final Optional<String> redirectUrl = Optional.of("redirectUrl");
+            final User user = User.builder().email("email").roles(List.of(
+                    Role.builder().name(RoleEnum.SUPER_ADMIN).build(),
+                    Role.builder().name(RoleEnum.ADMIN).build(),
+                    Role.builder().name(RoleEnum.APPLICANT).build(),
+                    Role.builder().name(RoleEnum.FIND).build()
+            )).build();
+
+            when(oneLoginService.getUser("email", "sub"))
+                    .thenReturn(Optional.of(user));
+
+            final RedirectView methodResponse = loginController.redirectAfterLogin(redirectUrl, response, "a-custom-valid-token");
+
+            verify(response).addCookie(customJwtCookie);
+            verify(oneLoginService).addSubToUser("sub", "email");
+            assertThat(methodResponse.getUrl()).isEqualTo("adminBaseUrl/super-admin/dashboard");
         }
 
         @Test
         void shouldGoToMigrateDataPage_WhenUserFoundWithoutSub_AndIsAnApplicant() {
+            final HttpServletResponse response = Mockito.spy(new MockHttpServletResponse());
+            final Optional<String> redirectUrl = Optional.of("redirectUrl");
+            final User user = User.builder().email("email").roles(List.of(
+                    Role.builder().name(RoleEnum.APPLICANT).build(),
+                    Role.builder().name(RoleEnum.FIND).build()
+            )).build();
 
+            when(oneLoginService.getUser("email", "sub"))
+                    .thenReturn(Optional.of(user));
+
+            final RedirectView methodResponse = loginController.redirectAfterLogin(redirectUrl, response, "a-custom-valid-token");
+
+            verify(response).addCookie(customJwtCookie);
+            assertThat(methodResponse.getUrl()).isEqualTo("/should-migrate-data");
         }
     }
 }


### PR DESCRIPTION
## Description

Ticket [#1935](https://technologyprogramme.atlassian.net/browse/GAP-1935)

Implementing redirect logic based on users ROLE, and if they've used our service as a COLA or OneLogin user before.
Also added a /v2/login endpoint that should redirect to OneLogins login endpoint

Left appropriate TODOs for future work:
https://technologyprogramme.atlassian.net/browse/GAP-1922
https://technologyprogramme.atlassian.net/browse/GAP-1932

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

![image (8)](https://github.com/cabinetoffice/gap-user-service/assets/101722961/d5cfb370-1e72-42ac-a2b6-4c7affa647cc)



# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
