### PR TITLE
ignore query params in authorize wiremock

### DIFF
--- a/mockOneLogin/wiremock/mappings/31a0374d-e721-4dc9-9a1c-157cfea2e5be.json
+++ b/mockOneLogin/wiremock/mappings/31a0374d-e721-4dc9-9a1c-157cfea2e5be.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "url": "/authorize"
+    "urlPath": "/authorize"
   },
   "response": {
     "status": 302,


### PR DESCRIPTION
minor QOL change for local dev so you don't have to manually edit the authorize query in the browser