### PR TITLE
Migrating a COLA applicants data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,10 @@
 			<artifactId>nimbus-jose-jwt</artifactId>
 			<version>9.31</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/gov/cabinetofice/gapuserservice/config/WebConfig.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/config/WebConfig.java
@@ -1,0 +1,11 @@
+package gov.cabinetofice.gapuserservice.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebConfig {
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+}

--- a/src/main/java/gov/cabinetofice/gapuserservice/dto/MigrateUserDto.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/dto/MigrateUserDto.java
@@ -1,0 +1,13 @@
+package gov.cabinetofice.gapuserservice.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+@Builder
+public class MigrateUserDto {
+    private String oneLoginSub;
+    private UUID colaSub;
+}

--- a/src/main/java/gov/cabinetofice/gapuserservice/enums/LoginJourneyRedirect.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/enums/LoginJourneyRedirect.java
@@ -26,13 +26,6 @@ public enum LoginJourneyRedirect {
         public String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie) {
             return redirectUrlCookie;
         }
-    },
-
-    MIGRATION_ERROR_PAGE {
-        @Override
-        public String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie) {
-            return adminBaseUrl + "/migration-error";
-        }
     };
 
     public abstract String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie);

--- a/src/main/java/gov/cabinetofice/gapuserservice/enums/LoginJourneyRedirect.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/enums/LoginJourneyRedirect.java
@@ -26,6 +26,13 @@ public enum LoginJourneyRedirect {
         public String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie) {
             return redirectUrlCookie;
         }
+    },
+
+    MIGRATION_ERROR_PAGE {
+        @Override
+        public String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie) {
+            return adminBaseUrl + "/migration-error";
+        }
     };
 
     public abstract String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie);

--- a/src/main/java/gov/cabinetofice/gapuserservice/enums/LoginJourneyRedirect.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/enums/LoginJourneyRedirect.java
@@ -5,56 +5,56 @@ import static gov.cabinetofice.gapuserservice.web.LoginControllerV2.PRIVACY_POLI
 public enum LoginJourneyRedirect {
     PRIVACY_POLICY_PAGE {
         @Override
-        public String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie) {
+        public String getRedirectUrl(String adminBaseUrl, String applicantBaseUrl, String redirectUrlCookie) {
             return PRIVACY_POLICY_PAGE_VIEW;
         }
     },
     SUPER_ADMIN_DASHBOARD {
         @Override
-        public String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie) {
+        public String getRedirectUrl(String adminBaseUrl, String applicantBaseUrl, String redirectUrlCookie) {
             return adminBaseUrl + "?redirectUrl=/super-admin-dashboard";
         }
     },
     ADMIN_DASHBOARD {
         @Override
-        public String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie) {
+        public String getRedirectUrl(String adminBaseUrl, String applicantBaseUrl, String redirectUrlCookie) {
             return adminBaseUrl + "?redirectUrl=/dashboard";
         }
     },
     APPLICANT_APP {
         @Override
-        public String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie) {
+        public String getRedirectUrl(String adminBaseUrl, String applicantBaseUrl, String redirectUrlCookie) {
             return redirectUrlCookie;
         }
     },
 
-    APPLICANT_DASHBOARD_MIGRATION_PASS {
+    APPLICANT_APP_MIGRATION_PASS {
         @Override
-        public String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie) {
-            return APPLICANT_APP.getRedirectUrl(adminBaseUrl, redirectUrlCookie) + "?migrationSucceeded=true";
+        public String getRedirectUrl(String adminBaseUrl, String applicantBaseUrl, String redirectUrlCookie) {
+            return APPLICANT_APP.getRedirectUrl(adminBaseUrl, applicantBaseUrl, redirectUrlCookie) + "?migrationSucceeded=true";
         }
     },
 
-    APPLICANT_DASHBOARD_MIGRATION_FAIL {
+    APPLICANT_APP_MIGRATION_FAIL {
         @Override
-        public String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie) {
-            return APPLICANT_APP.getRedirectUrl(adminBaseUrl, redirectUrlCookie) + "?migrationSucceeded=false";
+        public String getRedirectUrl(String adminBaseUrl, String applicantBaseUrl, String redirectUrlCookie) {
+            return applicantBaseUrl + "/dashboard?migrationSucceeded=false";
         }
     },
 
     ADMIN_DASHBOARD_MIGRATION_PASS {
         @Override
-        public String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie) {
-            return ADMIN_DASHBOARD.getRedirectUrl(adminBaseUrl, redirectUrlCookie) + "?migrationSucceeded=true";
+        public String getRedirectUrl(String adminBaseUrl, String applicantBaseUrl, String redirectUrlCookie) {
+            return ADMIN_DASHBOARD.getRedirectUrl(adminBaseUrl, applicantBaseUrl, redirectUrlCookie) + "?migrationSucceeded=true";
         }
     },
 
     ADMIN_DASHBOARD_MIGRATION_FAIL {
         @Override
-        public String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie) {
-            return ADMIN_DASHBOARD.getRedirectUrl(adminBaseUrl, redirectUrlCookie) + "?migrationSucceeded=false";
+        public String getRedirectUrl(String adminBaseUrl, String applicantBaseUrl, String redirectUrlCookie) {
+            return ADMIN_DASHBOARD.getRedirectUrl(adminBaseUrl, applicantBaseUrl, redirectUrlCookie) + "?migrationSucceeded=false";
         }
     };
 
-    public abstract String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie);
+    public abstract String getRedirectUrl(String adminBaseUrl, String applicantBaseUrl, String redirectUrlCookie);
 }

--- a/src/main/java/gov/cabinetofice/gapuserservice/enums/LoginJourneyRedirect.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/enums/LoginJourneyRedirect.java
@@ -3,7 +3,7 @@ package gov.cabinetofice.gapuserservice.enums;
 import static gov.cabinetofice.gapuserservice.web.LoginControllerV2.PRIVACY_POLICY_PAGE_VIEW;
 
 public enum LoginJourneyRedirect {
-    PRIVACY_POLICY_PAGE{
+    PRIVACY_POLICY_PAGE {
         @Override
         public String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie) {
             return PRIVACY_POLICY_PAGE_VIEW;
@@ -25,6 +25,34 @@ public enum LoginJourneyRedirect {
         @Override
         public String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie) {
             return redirectUrlCookie;
+        }
+    },
+
+    APPLICANT_DASHBOARD_MIGRATION_PASS {
+        @Override
+        public String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie) {
+            return APPLICANT_APP.getRedirectUrl(adminBaseUrl, redirectUrlCookie) + "?migrationSucceeded=true";
+        }
+    },
+
+    APPLICANT_DASHBOARD_MIGRATION_FAIL {
+        @Override
+        public String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie) {
+            return APPLICANT_APP.getRedirectUrl(adminBaseUrl, redirectUrlCookie) + "?migrationSucceeded=false";
+        }
+    },
+
+    ADMIN_DASHBOARD_MIGRATION_PASS {
+        @Override
+        public String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie) {
+            return ADMIN_DASHBOARD.getRedirectUrl(adminBaseUrl, redirectUrlCookie) + "?migrationSucceeded=true";
+        }
+    },
+
+    ADMIN_DASHBOARD_MIGRATION_FAIL {
+        @Override
+        public String getRedirectUrl(String adminBaseUrl, String redirectUrlCookie) {
+            return ADMIN_DASHBOARD.getRedirectUrl(adminBaseUrl, redirectUrlCookie) + "?migrationSucceeded=false";
         }
     };
 

--- a/src/main/java/gov/cabinetofice/gapuserservice/enums/LoginJourneyState.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/enums/LoginJourneyState.java
@@ -12,6 +12,7 @@ public enum LoginJourneyState {
                                            final User user,
                                            final String jwt,
                                            final Logger logger) {
+            logger.debug("User: " + user.getSub() + " accepted the privacy policy");
             oneLoginService.setUsersLoginJourneyState(user, PRIVACY_POLICY_ACCEPTED);
             return PRIVACY_POLICY_ACCEPTED.nextState(oneLoginService, user, jwt, logger);
         }
@@ -40,6 +41,7 @@ public enum LoginJourneyState {
                                            final User user,
                                            final String jwt,
                                            final Logger logger) {
+            logger.debug("Migrating user: " + user.getSub());
             LoginJourneyState nextState;
             try {
                 oneLoginService.migrateUser(user, jwt);
@@ -70,7 +72,7 @@ public enum LoginJourneyState {
             return switch (role) {
                 case SUPER_ADMIN -> LoginJourneyRedirect.SUPER_ADMIN_DASHBOARD;
                 case ADMIN -> LoginJourneyRedirect.ADMIN_DASHBOARD_MIGRATION_PASS;
-                case APPLICANT, FIND -> LoginJourneyRedirect.APPLICANT_DASHBOARD_MIGRATION_PASS;
+                case APPLICANT, FIND -> LoginJourneyRedirect.APPLICANT_APP_MIGRATION_PASS;
             };
         }
     },
@@ -90,7 +92,7 @@ public enum LoginJourneyState {
             return switch (role) {
                 case SUPER_ADMIN -> LoginJourneyRedirect.SUPER_ADMIN_DASHBOARD;
                 case ADMIN -> LoginJourneyRedirect.ADMIN_DASHBOARD_MIGRATION_FAIL;
-                case APPLICANT, FIND -> LoginJourneyRedirect.APPLICANT_DASHBOARD_MIGRATION_FAIL;
+                case APPLICANT, FIND -> LoginJourneyRedirect.APPLICANT_APP_MIGRATION_FAIL;
             };
         }
     },

--- a/src/main/java/gov/cabinetofice/gapuserservice/enums/LoginJourneyState.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/enums/LoginJourneyState.java
@@ -3,13 +3,17 @@ package gov.cabinetofice.gapuserservice.enums;
 import gov.cabinetofice.gapuserservice.model.RoleEnum;
 import gov.cabinetofice.gapuserservice.model.User;
 import gov.cabinetofice.gapuserservice.service.OneLoginService;
+import org.apache.logging.log4j.Logger;
 
 public enum LoginJourneyState {
     PRIVACY_POLICY_PENDING {
         @Override
-        public LoginJourneyState nextState(final OneLoginService oneLoginService, final User user) {
+        public LoginJourneyState nextState(final OneLoginService oneLoginService,
+                                           final User user,
+                                           final String jwt,
+                                           final Logger logger) {
             oneLoginService.setUsersLoginJourneyState(user, PRIVACY_POLICY_ACCEPTED);
-            return PRIVACY_POLICY_ACCEPTED.nextState(oneLoginService, user);
+            return PRIVACY_POLICY_ACCEPTED.nextState(oneLoginService, user, jwt, logger);
         }
 
         @Override
@@ -20,76 +24,97 @@ public enum LoginJourneyState {
 
     PRIVACY_POLICY_ACCEPTED {
         @Override
-        public LoginJourneyState nextState(final OneLoginService oneLoginService, final User user) {
+        public LoginJourneyState nextState(final OneLoginService oneLoginService,
+                                           final User user,
+                                           final String jwt,
+                                           final Logger logger) {
             final LoginJourneyState nextState = user.hasColaSub() ? MIGRATING_USER : USER_READY;
             oneLoginService.setUsersLoginJourneyState(user, nextState);
-            return nextState.nextState(oneLoginService, user);
+            return nextState.nextState(oneLoginService, user, jwt, logger);
         }
     },
 
     MIGRATING_USER {
         @Override
-        public LoginJourneyState nextState(final OneLoginService oneLoginService, final User user) {
+        public LoginJourneyState nextState(final OneLoginService oneLoginService,
+                                           final User user,
+                                           final String jwt,
+                                           final Logger logger) {
             LoginJourneyState nextState;
             try {
-                oneLoginService.migrateUser(user);
+                oneLoginService.migrateUser(user, jwt);
                 nextState = MIGRATION_SUCCEEDED;
+                logger.info("Successfully migrated user: " + user.getSub());
             } catch (Exception e) {
-                // TODO log error
                 nextState = MIGRATION_FAILED;
+                logger.error("Failed to migrate user: " + user.getSub(), e);
             }
+
             oneLoginService.setUsersLoginJourneyState(user, nextState);
-            return nextState.nextState(oneLoginService, user);
+            return nextState.nextState(oneLoginService, user, jwt, logger);
         }
     },
 
     MIGRATION_SUCCEEDED {
         @Override
-        public LoginJourneyState nextState(OneLoginService oneLoginService, User user) {
+        public LoginJourneyState nextState(final OneLoginService oneLoginService,
+                                           final User user,
+                                           final String jwt,
+                                           final Logger logger) {
             oneLoginService.setUsersLoginJourneyState(user, USER_READY);
             return this;
         }
 
         @Override
         public LoginJourneyRedirect getLoginJourneyRedirect(final RoleEnum role) {
-            return redirectToRelevantApp(role);
+            return switch (role) {
+                case SUPER_ADMIN -> LoginJourneyRedirect.SUPER_ADMIN_DASHBOARD;
+                case ADMIN -> LoginJourneyRedirect.ADMIN_DASHBOARD_MIGRATION_PASS;
+                case APPLICANT, FIND -> LoginJourneyRedirect.APPLICANT_DASHBOARD_MIGRATION_PASS;
+            };
         }
     },
 
     MIGRATION_FAILED {
         @Override
-        public LoginJourneyState nextState(OneLoginService oneLoginService, User user) {
+        public LoginJourneyState nextState(final OneLoginService oneLoginService,
+                                           final User user,
+                                           final String jwt,
+                                           final Logger logger) {
             oneLoginService.setUsersLoginJourneyState(user, USER_READY);
             return this;
         }
 
         @Override
         public LoginJourneyRedirect getLoginJourneyRedirect(final RoleEnum role) {
-            return redirectToRelevantApp(role);
+            return switch (role) {
+                case SUPER_ADMIN -> LoginJourneyRedirect.SUPER_ADMIN_DASHBOARD;
+                case ADMIN -> LoginJourneyRedirect.ADMIN_DASHBOARD_MIGRATION_FAIL;
+                case APPLICANT, FIND -> LoginJourneyRedirect.APPLICANT_DASHBOARD_MIGRATION_FAIL;
+            };
         }
     },
 
     USER_READY {
         @Override
-        public LoginJourneyState nextState(OneLoginService oneLoginService, User user) {
+        public LoginJourneyState nextState(final OneLoginService oneLoginService,
+                                           final User user,
+                                           final String jwt,
+                                           final Logger logger) {
             return this;
         }
 
         @Override
         public LoginJourneyRedirect getLoginJourneyRedirect(final RoleEnum role) {
-            return redirectToRelevantApp(role);
+            return switch (role) {
+                case SUPER_ADMIN -> LoginJourneyRedirect.SUPER_ADMIN_DASHBOARD;
+                case ADMIN -> LoginJourneyRedirect.ADMIN_DASHBOARD;
+                case APPLICANT, FIND -> LoginJourneyRedirect.APPLICANT_APP;
+            };
         }
     };
 
-    private static LoginJourneyRedirect redirectToRelevantApp(final RoleEnum role) {
-        return switch (role) {
-            case SUPER_ADMIN -> LoginJourneyRedirect.SUPER_ADMIN_DASHBOARD;
-            case ADMIN -> LoginJourneyRedirect.ADMIN_DASHBOARD;
-            case APPLICANT, FIND -> LoginJourneyRedirect.APPLICANT_APP;
-        };
-    }
-
-    public abstract LoginJourneyState nextState(final OneLoginService oneLoginService, final User user);
+    public abstract LoginJourneyState nextState(final OneLoginService oneLoginService, final User user, final String jwt, final Logger logger);
 
     public LoginJourneyRedirect getLoginJourneyRedirect(final RoleEnum role) {
         throw new UnsupportedOperationException("Error, make sure the enums next state function eventually ends up on a state that has a redirect URL");

--- a/src/main/java/gov/cabinetofice/gapuserservice/model/User.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/model/User.java
@@ -8,6 +8,7 @@ import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -29,6 +30,9 @@ public class User {
 
     @Column(name = "sub")
     private String sub;
+
+    @Column(name = "cola_sub")
+    private UUID colaSub;
 
     @Column(name = "login_journey_state")
     @Enumerated(EnumType.STRING)
@@ -63,6 +67,10 @@ public class User {
 
     public boolean hasDepartment() {
         return this.department != null;
+    }
+
+    public boolean hasColaSub() {
+        return this.colaSub != null;
     }
 
     public boolean isApplicant() {

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/OneLoginService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/OneLoginService.java
@@ -190,7 +190,7 @@ public class OneLoginService {
                 .build();
         webClientBuilder.build()
                 .patch()
-                .uri("http://localhost:8080/users/migrate")
+                .uri(adminBaseUrl + "/api/users/migrate")
                 .header("Authorization", "Bearer " + jwt)
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(requestBody)

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/OneLoginService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/OneLoginService.java
@@ -173,4 +173,7 @@ public class OneLoginService {
             throw new AuthenticationException("unable to retrieve access_token");
         }
     }
+
+    public void migrateApplicant(final User user) {
+    }
 }

--- a/src/main/java/gov/cabinetofice/gapuserservice/util/RestUtils.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/util/RestUtils.java
@@ -5,7 +5,6 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClients;
@@ -35,17 +34,7 @@ public class RestUtils {
         HttpResponse response = httpClient.execute(httpGet);
         return convertResponseToJson(response);
     }
-
-    public static JSONObject patchRequestWithBody(String url, String body, String contentType) throws IOException {
-        HttpClient httpClient = HttpClients.createDefault();
-        HttpPatch httpPatch = new HttpPatch(url);
-        httpPatch.setHeader(HttpHeaders.CONTENT_TYPE, contentType);
-
-        httpPatch.setEntity(new StringEntity(body));
-        HttpResponse response = httpClient.execute(httpPatch);
-        return convertResponseToJson(response);
-    }
-
+    
     private static JSONObject convertResponseToJson(HttpResponse response) throws IOException {
         HttpEntity entity = response.getEntity();
 

--- a/src/main/java/gov/cabinetofice/gapuserservice/util/RestUtils.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/util/RestUtils.java
@@ -5,6 +5,7 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClients;
@@ -24,7 +25,6 @@ public class RestUtils {
         httpPost.setEntity(new StringEntity(body));
         HttpResponse response = httpClient.execute(httpPost);
         return convertResponseToJson(response);
-
     }
 
     public static JSONObject getRequestWithHeaders(String url, Map<String, String> headers) throws IOException {
@@ -34,7 +34,16 @@ public class RestUtils {
 
         HttpResponse response = httpClient.execute(httpGet);
         return convertResponseToJson(response);
+    }
 
+    public static JSONObject patchRequestWithBody(String url, String body, String contentType) throws IOException {
+        HttpClient httpClient = HttpClients.createDefault();
+        HttpPatch httpPatch = new HttpPatch(url);
+        httpPatch.setHeader(HttpHeaders.CONTENT_TYPE, contentType);
+
+        httpPatch.setEntity(new StringEntity(body));
+        HttpResponse response = httpClient.execute(httpPatch);
+        return convertResponseToJson(response);
     }
 
     private static JSONObject convertResponseToJson(HttpResponse response) throws IOException {

--- a/src/main/java/gov/cabinetofice/gapuserservice/util/RestUtils.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/util/RestUtils.java
@@ -34,7 +34,7 @@ public class RestUtils {
         HttpResponse response = httpClient.execute(httpGet);
         return convertResponseToJson(response);
     }
-    
+
     private static JSONObject convertResponseToJson(HttpResponse response) throws IOException {
         HttpEntity entity = response.getEntity();
 

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
@@ -55,6 +55,9 @@ public class LoginControllerV2 {
     @Value("${admin-base-url}")
     private String adminBaseUrl;
 
+    @Value("${applicant-base-url}")
+    private String applicantBaseUrl;
+
     @GetMapping("/login")
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     public RedirectView login(final @RequestParam(name = REDIRECT_URL_NAME) Optional<String> redirectUrlParam,
@@ -85,7 +88,7 @@ public class LoginControllerV2 {
         addCustomJwtCookie(response, userInfo);
         return new RedirectView(user.getLoginJourneyState()
                 .getLoginJourneyRedirect(user.getRole().getName())
-                .getRedirectUrl(adminBaseUrl, redirectUrlCookie));
+                .getRedirectUrl(adminBaseUrl, applicantBaseUrl, redirectUrlCookie));
     }
 
     @GetMapping("/notice-page")
@@ -134,6 +137,6 @@ public class LoginControllerV2 {
         return user.getLoginJourneyState()
                 .nextState(oneLoginService, user, jwt, log)
                 .getLoginJourneyRedirect(user.getRole().getName())
-                .getRedirectUrl(adminBaseUrl, redirectUrlCookie);
+                .getRedirectUrl(adminBaseUrl, applicantBaseUrl, redirectUrlCookie);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -55,4 +55,6 @@ onelogin.service-redirect-url=redirectUrlValue
 onelogin.private-key=privateKeyValue
 feature.onelogin.enabled=false
 
+find-a-grant.url=http://localhost:3000
 admin-base-url=http://localhost:3000/apply/admin
+applicant-base-url=http://localhost:3000/apply/applicant

--- a/src/main/resources/db/migration/V1_11__add_cola_sub_to_user.sql
+++ b/src/main/resources/db/migration/V1_11__add_cola_sub_to_user.sql
@@ -1,0 +1,2 @@
+ALTER TABLE gap_users
+ADD COLUMN cola_sub UUID;

--- a/src/test/java/gov/cabinetofice/gapuserservice/service/OneLoginServiceTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/service/OneLoginServiceTest.java
@@ -1,5 +1,6 @@
 package gov.cabinetofice.gapuserservice.service;
 
+import gov.cabinetofice.gapuserservice.dto.MigrateUserDto;
 import gov.cabinetofice.gapuserservice.dto.OneLoginUserInfoDto;
 import gov.cabinetofice.gapuserservice.enums.LoginJourneyState;
 import gov.cabinetofice.gapuserservice.exceptions.*;
@@ -23,6 +24,8 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 import java.io.IOException;
 import java.security.*;
@@ -54,6 +57,9 @@ public class OneLoginServiceTest {
     @Mock
     private RoleRepository roleRepository;
 
+    @Mock
+    private WebClient.Builder webClientBuilder;
+
     @BeforeEach
     void setUp() {
         mockedStatic = mockStatic(RestUtils.class);
@@ -63,6 +69,7 @@ public class OneLoginServiceTest {
         ReflectionTestUtils.setField(oneLoginService, "clientAssertionType", "assertion_type");
         ReflectionTestUtils.setField(oneLoginService, "clientId", DUMMY_CLIENT_ID);
         ReflectionTestUtils.setField(oneLoginService, "serviceRedirectUrl", DUMMY_BASE_URL + "/redirect");
+        ReflectionTestUtils.setField(oneLoginService, "adminBaseUrl", "adminBaseUrl");
     }
 
     @AfterEach
@@ -339,6 +346,44 @@ public class OneLoginServiceTest {
             final User result = oneLoginService.createOrGetUserFromInfo(oneLoginUserInfoDto);
 
             Assertions.assertEquals(newUser, result);
+        }
+    }
+
+    @Nested
+    class migrateUser {
+        @Test
+        void shouldMigrateUser() {
+            final User user = User.builder()
+                    .colaSub(UUID.randomUUID())
+                    .sub("oneLoginSub")
+                    .build();
+            final MigrateUserDto migrateUserDto = MigrateUserDto.builder()
+                    .oneLoginSub(user.getSub())
+                    .colaSub(user.getColaSub())
+                    .build();
+
+            // TODO not sure how to spy/mock the builder pattern well. If anyone has a better way gimme a shout!
+            final WebClient mockWebClient = mock(WebClient.class);
+            final WebClient.RequestBodyUriSpec mockRequestBodyUriSpec = mock(WebClient.RequestBodyUriSpec.class);
+            final WebClient.RequestBodySpec mockRequestBodySpec = mock(WebClient.RequestBodySpec.class);
+            final WebClient.RequestHeadersSpec mockRequestHeadersSpec = mock(WebClient.RequestHeadersSpec.class);
+            final WebClient.ResponseSpec mockResponseSpec = mock(WebClient.ResponseSpec.class);
+
+            when(webClientBuilder.build()).thenReturn(mockWebClient);
+            when(mockWebClient.patch()).thenReturn(mockRequestBodyUriSpec);
+            when(mockRequestBodyUriSpec.uri(anyString())).thenReturn(mockRequestBodySpec);
+            when(mockRequestBodySpec.header(anyString(), anyString())).thenReturn(mockRequestBodySpec);
+            when(mockRequestBodySpec.contentType(any())).thenReturn(mockRequestBodySpec);
+            when(mockRequestBodySpec.bodyValue(any())).thenReturn(mockRequestHeadersSpec);
+            when(mockRequestHeadersSpec.retrieve()).thenReturn(mockResponseSpec);
+            when(mockResponseSpec.bodyToMono(Void.class)).thenReturn(mock(Mono.class));
+
+            oneLoginService.migrateUser(user, "jwt");
+
+            verify(webClientBuilder).build();
+            verify(mockRequestBodyUriSpec).uri("adminBaseUrl/api/users/migrate");
+            verify(mockRequestBodySpec).header("Authorization", "Bearer jwt");
+            verify(mockRequestBodySpec).bodyValue(migrateUserDto);
         }
     }
 


### PR DESCRIPTION
When a user first accepts the privacy policy, and if the user has a COLA sub:
- We set their state to `MIGRATING_USER`
- Call the admin backend to migrate this user (as the admin backend has access to applys DB)
   - (Authing via the jwt as there is no admin session at this stage in the journey)
   - Just sending the cola sub & one login sub
- If the migration succeeds, set their state to `MIGRATION_SUCCEEDED`
   - Redirect to relevant app with `?migrationSucceeded=true` query param (unless users an SA)
   - if they're an applicant, the dashboard page will display the success banner but we cant expect to add a banner to every page
   - Then sets the users state to `USER_READY` so the banner is only displayed once
- If the migration fails, set their state to `MIGRATION_FAILED`
   - Redirect to relevant app with `?migrationSucceeded=true` query param (unless users an SA)
   - If they're an applicant - force redirection to the dashboard as we always want to show the error banner here
   - Then sets the users state to `USER_READY` so the banner is only displayed once

Added some logs during the login journey to hopefully make debugging any issues a bit easier
