### PR TITLE
GAP-2070 delete applicant

### DIFF
--- a/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
@@ -169,7 +169,7 @@ public class OneLoginUserService {
         final User user = userRepository.findById(id).orElseThrow(() -> new UserNotFoundException("user with id: " + id + "not found"));
         webClientBuilder.build()
                 .delete()
-                .uri(adminBackend + "/users/delete/" + user.getSub() + (user.hasColaSub() ? "?colaSub=" + user.getColaSub() : ""))
+                .uri(adminBackend + "/users/delete/" + (user.hasSub() ? user.getSub() : "") + (user.hasColaSub() ? "?colaSub=" + user.getColaSub() : ""))
                 .header("Authorization", "Bearer " + jwt)
                 .retrieve()
                 .bodyToMono(Void.class)

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
@@ -42,10 +42,10 @@ public class OneLoginUserService {
     private final JwtBlacklistService jwtBlacklistService;
     private final ApplicationConfigProperties configProperties;
     private final ThirdPartyAuthProviderProperties authenticationProvider;
+    private final WebClient.Builder webClientBuilder;
 
     @Value("${jwt.cookie-name}")
     public String userServiceCookieName;
-    private final WebClient.Builder webClientBuilder;
 
     @Value("${admin-backend}")
     private String adminBackend;

--- a/src/main/java/gov/cabinetofice/gapuserservice/util/HelperUtils.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/util/HelperUtils.java
@@ -4,8 +4,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import gov.cabinetofice.gapuserservice.exceptions.UnauthorizedException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.WebUtils;
 
 import java.security.SecureRandom;
 import java.util.Objects;
@@ -67,5 +71,12 @@ public class HelperUtils {
                 .mapToObj(chrs::charAt)
                 .collect(StringBuilder::new, StringBuilder::append, StringBuilder::append)
                 .toString();
+    }
+
+    public static Cookie getCustomJwtCookieFromRequest(final HttpServletRequest request, final String userServiceCookieName) {
+        final Cookie customJWTCookie = WebUtils.getCookie(request, userServiceCookieName);
+        if (customJWTCookie == null)
+            throw new UnauthorizedException(userServiceCookieName + " cookie not found");
+        return customJWTCookie;
     }
 }

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
@@ -20,7 +20,6 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.json.JSONObject;
@@ -45,7 +44,6 @@ import static gov.cabinetofice.gapuserservice.util.HelperUtils.getCustomJwtCooki
 @RequestMapping("v2")
 @ConditionalOnProperty(value = "feature.onelogin.enabled", havingValue = "true")
 @Log4j2
-@Getter
 public class LoginControllerV2 {
     private final OneLoginService oneLoginService;
     private final CustomJwtServiceImpl customJwtService;

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
@@ -8,7 +8,6 @@ import gov.cabinetofice.gapuserservice.dto.IdTokenDto;
 import gov.cabinetofice.gapuserservice.dto.OneLoginUserInfoDto;
 import gov.cabinetofice.gapuserservice.dto.PrivacyPolicyDto;
 import gov.cabinetofice.gapuserservice.dto.StateCookieDto;
-import gov.cabinetofice.gapuserservice.exceptions.UnauthorizedException;
 import gov.cabinetofice.gapuserservice.exceptions.UserNotFoundException;
 import gov.cabinetofice.gapuserservice.model.Nonce;
 import gov.cabinetofice.gapuserservice.model.User;
@@ -38,6 +37,8 @@ import org.springframework.web.util.WebUtils;
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
+
+import static gov.cabinetofice.gapuserservice.util.HelperUtils.getCustomJwtCookieFromRequest;
 
 @RequiredArgsConstructor
 @Controller
@@ -101,7 +102,7 @@ public class LoginControllerV2 {
     public RedirectView redirectAfterLogin(
             final @CookieValue(name = STATE_COOKIE) String stateCookie,
             final HttpServletResponse response,
-             final @RequestParam String code,
+            final @RequestParam String code,
             final @RequestParam String state) {
 
         final JSONObject tokenResponse = oneLoginService.getOneLoginUserTokenResponse(code);
@@ -143,7 +144,7 @@ public class LoginControllerV2 {
             final @CookieValue(name = REDIRECT_URL_NAME, required = false) Optional<String> redirectUrlCookie) {
         if (result.hasErrors())
             return submitToPrivacyPolicyPage(privacyPolicyDto);
-        final Cookie customJWTCookie = getCustomJwtCookieFromRequest(request);
+        final Cookie customJWTCookie = getCustomJwtCookieFromRequest(request, userServiceCookieName);
         final User user = getUserFromCookie(customJWTCookie)
                 .orElseThrow(() -> new UserNotFoundException("Privacy policy: Could not fetch user from jwt"));
         return new ModelAndView("redirect:" + runStateMachine(redirectUrlCookie
@@ -171,13 +172,6 @@ public class LoginControllerV2 {
     private Optional<User> getUserFromCookie(final Cookie customJWTCookie) {
         final DecodedJWT decodedJWT = JWT.decode(customJWTCookie.getValue());
         return oneLoginService.getUserFromSub(decodedJWT.getSubject());
-    }
-
-    private Cookie getCustomJwtCookieFromRequest(final HttpServletRequest request) {
-        final Cookie customJWTCookie = WebUtils.getCookie(request, userServiceCookieName);
-        if (customJWTCookie == null)
-            throw new UnauthorizedException(userServiceCookieName + " cookie not found");
-        return customJWTCookie;
     }
 
     private void verifyStateAndNonce(final String nonce, final StateCookieDto stateCookieDto, final String state) {

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/UserController.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/UserController.java
@@ -82,6 +82,7 @@ public class UserController {
         if (!roleService.isSuperAdmin(httpRequest)) {
             throw new ForbiddenException();
         }
+        final Cookie customJWTCookie = getCustomJwtCookieFromRequest(httpRequest, userServiceCookieName);
 
         oneLoginUserService.updateRoles(id, roleIds);
         return ResponseEntity.ok("success");

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/UserController.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/UserController.java
@@ -8,14 +8,18 @@ import gov.cabinetofice.gapuserservice.model.User;
 import gov.cabinetofice.gapuserservice.service.DepartmentService;
 import gov.cabinetofice.gapuserservice.service.RoleService;
 import gov.cabinetofice.gapuserservice.service.user.OneLoginUserService;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+
+import static gov.cabinetofice.gapuserservice.util.HelperUtils.getCustomJwtCookieFromRequest;
 
 
 @RequiredArgsConstructor
@@ -26,6 +30,9 @@ public class UserController {
     private final OneLoginUserService oneLoginUserService;
     private final DepartmentService departmentService;
     private final RoleService roleService;
+
+    @Value("${jwt.cookie-name}")
+    public String userServiceCookieName;
 
     @GetMapping("/isSuperAdmin")
     public ResponseEntity<String> isSuperAdmin(HttpServletRequest httpRequest) {
@@ -85,8 +92,9 @@ public class UserController {
         if (!roleService.isSuperAdmin(httpRequest)) {
             throw new ForbiddenException();
         }
+        final Cookie customJWTCookie = getCustomJwtCookieFromRequest(httpRequest, userServiceCookieName);
 
-        oneLoginUserService.deleteUser(id);
+        oneLoginUserService.deleteUser(id, customJWTCookie.getValue());
         return ResponseEntity.ok("success");
     }
 }

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/UserController.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/UserController.java
@@ -100,8 +100,6 @@ public class UserController {
         if (!roleService.isSuperAdmin(httpRequest)) {
             throw new ForbiddenException();
         }
-        final Cookie customJWTCookie = getCustomJwtCookieFromRequest(httpRequest, userServiceCookieName);
-
         oneLoginUserService.updateRoles(id, roleIds);
         return ResponseEntity.ok("success");
     }

--- a/src/test/java/gov/cabinetofice/gapuserservice/util/HelperUtilsTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/util/HelperUtilsTest.java
@@ -1,11 +1,19 @@
 package gov.cabinetofice.gapuserservice.util;
 
+import gov.cabinetofice.gapuserservice.exceptions.UnauthorizedException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class HelperUtilsTest {
@@ -15,6 +23,27 @@ public class HelperUtilsTest {
         Set<String> output = Set.of("FIND", "APPLY", "ADMIN");
         Set<String> result = HelperUtils.removeSquareBracketsAndTrim(input);
         assert(result.equals(output));
+    }
+
+    @Test
+    void getCustomJwtCookieFromRequestShouldReturnCookie() {
+        final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
+        when(httpRequest.getCookies()).thenReturn(new Cookie[] { new Cookie("cookieName", "cookieValue") });
+
+        final Cookie cookie = HelperUtils.getCustomJwtCookieFromRequest(httpRequest, "cookieName");
+
+        assertEquals("cookieName", cookie.getName());
+        assertEquals("cookieValue", cookie.getValue());
+    }
+
+    @Test
+    void getCustomJwtCookieFromRequestShouldThrowException() {
+        final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
+        when(httpRequest.getCookies()).thenReturn(null);
+
+        assertThrows(UnauthorizedException.class, () -> {
+            HelperUtils.getCustomJwtCookieFromRequest(httpRequest, "cookieName");
+        });
     }
 
 }

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
@@ -22,21 +22,23 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 import org.springframework.web.util.WebUtils;
-import org.json.JSONObject;
 
 import java.util.*;
 
@@ -120,7 +122,7 @@ class LoginControllerV2Test {
             verify(response).addCookie(argument.capture());
             Cookie stateCookie = argument.getValue();
 
-            assertThat(stateCookie.getName()).isEqualTo(loginController.getSTATE_COOKIE());
+            assertThat(stateCookie.getName()).isEqualTo("state");
             assertThat(stateCookie.getValue()).isEqualTo("eyJyZWRpcmVjdFVybCI6Imh0dHBzOi8vd3d3LmZpbmQtZ292ZXJubWVudC1ncmFudHMuc2VydmljZS5nb3YudWsvIiwic3RhdGUiOiJzdGF0ZSJ9");
             assertThat(stateCookie.isHttpOnly()).isEqualTo(true);
             assertThat(stateCookie.getSecure()).isEqualTo(true);

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
@@ -7,9 +7,9 @@ import gov.cabinetofice.gapuserservice.dto.OneLoginUserInfoDto;
 import gov.cabinetofice.gapuserservice.dto.PrivacyPolicyDto;
 import gov.cabinetofice.gapuserservice.dto.StateCookieDto;
 import gov.cabinetofice.gapuserservice.enums.LoginJourneyState;
+import gov.cabinetofice.gapuserservice.exceptions.NonceExpiredException;
 import gov.cabinetofice.gapuserservice.exceptions.UnauthorizedClientException;
 import gov.cabinetofice.gapuserservice.exceptions.UnauthorizedException;
-import gov.cabinetofice.gapuserservice.exceptions.NonceExpiredException;
 import gov.cabinetofice.gapuserservice.model.Nonce;
 import gov.cabinetofice.gapuserservice.model.Role;
 import gov.cabinetofice.gapuserservice.model.RoleEnum;
@@ -34,7 +34,6 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -134,7 +133,7 @@ class LoginControllerV2Test {
             Cookie stateCookie = argument.getValue();
 
             assertThat(stateCookie.getName()).isEqualTo("state");
-            assertThat(stateCookie.getValue()).isEqualTo("eyJyZWRpcmVjdFVybCI6Imh0dHBzOi8vd3d3LmZpbmQtZ292ZXJubWVudC1ncmFudHMuc2VydmljZS5nb3YudWsvIiwic3RhdGUiOiJzdGF0ZSJ9");
+            assertThat(stateCookie.getValue()).isEqualTo("eyJyZWRpcmVjdFVybCI6Imh0dHBzOi8vd3d3LmZpbmQtZ292ZXJubWVudC1ncmFudHMuc2VydmljZS5nb3YudWsvIiwic2FsdElkIjoic2FsdElkIiwic3RhdGUiOiJzdGF0ZSJ9");
             assertThat(stateCookie.isHttpOnly()).isEqualTo(true);
             assertThat(stateCookie.getSecure()).isEqualTo(true);
             assertThat(stateCookie.getMaxAge()).isEqualTo(3600);

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/UserControllerTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/UserControllerTest.java
@@ -3,7 +3,6 @@ package gov.cabinetofice.gapuserservice.web;
 import gov.cabinetofice.gapuserservice.dto.ChangeDepartmentPageDto;
 import gov.cabinetofice.gapuserservice.dto.DepartmentDto;
 import gov.cabinetofice.gapuserservice.dto.UserDto;
-import gov.cabinetofice.gapuserservice.exceptions.ForbiddenException;
 import gov.cabinetofice.gapuserservice.exceptions.InvalidRequestException;
 import gov.cabinetofice.gapuserservice.model.Role;
 import gov.cabinetofice.gapuserservice.model.RoleEnum;
@@ -11,13 +10,16 @@ import gov.cabinetofice.gapuserservice.model.User;
 import gov.cabinetofice.gapuserservice.service.DepartmentService;
 import gov.cabinetofice.gapuserservice.service.RoleService;
 import gov.cabinetofice.gapuserservice.service.user.OneLoginUserService;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.Objects;
@@ -39,6 +41,11 @@ class UserControllerTest {
     @Mock
     private RoleService roleService;
 
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(controller, "userServiceCookieName", "userServiceCookieName");
+    }
+
     @Test
     void updateRolesForUserId() {
         final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
@@ -47,6 +54,7 @@ class UserControllerTest {
 
         assertThat(methodResponse).isEqualTo(ResponseEntity.ok("success"));
     }
+
     @Test
     void shouldReturnUserWhenValidIdIsGiven() {
         final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
@@ -85,6 +93,7 @@ class UserControllerTest {
     @Test
     void shouldDeleteUserWhenValidIdIsGiven() {
         final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
+        when(httpRequest.getCookies()).thenReturn(new Cookie[] {new Cookie("userServiceCookieName", "1")});
         when(roleService.isSuperAdmin(httpRequest)).thenReturn(true);
         final ResponseEntity<String> methodResponse = controller.deleteUser(httpRequest, 1);
 

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/UserControllerTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/UserControllerTest.java
@@ -3,6 +3,7 @@ package gov.cabinetofice.gapuserservice.web;
 import gov.cabinetofice.gapuserservice.dto.ChangeDepartmentPageDto;
 import gov.cabinetofice.gapuserservice.dto.DepartmentDto;
 import gov.cabinetofice.gapuserservice.dto.UserDto;
+import gov.cabinetofice.gapuserservice.exceptions.ForbiddenException;
 import gov.cabinetofice.gapuserservice.exceptions.InvalidRequestException;
 import gov.cabinetofice.gapuserservice.model.Role;
 import gov.cabinetofice.gapuserservice.model.RoleEnum;
@@ -129,6 +130,7 @@ class UserControllerTest {
     @Test
     void shouldThrowErrorWhenAdminTriesToDeleteThemselves() {
         final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
+        when(httpRequest.getCookies()).thenReturn(new Cookie[] {new Cookie("userServiceCookieName", "1")});
         when(roleService.isSuperAdmin(httpRequest)).thenReturn(true);
         when(customJwtService.getUserFromJwt(httpRequest)).thenReturn(Optional.of(User.builder().gapUserId(1).build()));
 
@@ -138,6 +140,7 @@ class UserControllerTest {
     @Test
     void shouldThrowErrorWhenUserIsEmpty() {
         final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
+        when(httpRequest.getCookies()).thenReturn(new Cookie[] {new Cookie("userServiceCookieName", "1")});
         when(roleService.isSuperAdmin(httpRequest)).thenReturn(true);
         when(customJwtService.getUserFromJwt(httpRequest)).thenReturn(Optional.empty());
 


### PR DESCRIPTION
Hard deletes an applicant after an admin deletes them. Yeets their entries from the following tables:
- Submissions
- Applicant org details
- grant export
- attachements

Two known caveats:
- Preserving data in grant_beneficiary as its not personally identifiably & useful for stats
- If an admin has already downloaded a deleted users submitted submissions, they will still of course have that data