### PR TITLE
GAP-2060 - Enhanced block

### DIFF
--- a/src/main/java/gov/cabinetofice/gapuserservice/security/WebSecurityConfig.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/security/WebSecurityConfig.java
@@ -52,7 +52,8 @@ public class WebSecurityConfig {
                 "/is-user-logged-in",
                 "/redirect-after-cola-login",
                 "/error/**",
-                "/.well-known/jwks.json"
+                "/.well-known/jwks.json",
+                "/v2/verifyAdminSession"
                 );
     }
 

--- a/src/main/java/gov/cabinetofice/gapuserservice/security/WebSecurityConfig.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/security/WebSecurityConfig.java
@@ -53,7 +53,7 @@ public class WebSecurityConfig {
                 "/redirect-after-cola-login",
                 "/error/**",
                 "/.well-known/jwks.json",
-                "/v2/validateAdminSession",
+                "/v2/validateSessionsRoles",
                 "/user"
                 );
     }

--- a/src/main/java/gov/cabinetofice/gapuserservice/security/WebSecurityConfig.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/security/WebSecurityConfig.java
@@ -53,7 +53,7 @@ public class WebSecurityConfig {
                 "/redirect-after-cola-login",
                 "/error/**",
                 "/.well-known/jwks.json",
-                "/v2/verifyAdminSession",
+                "/v2/validateAdminSession",
                 "/user"
                 );
     }

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/OneLoginService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/OneLoginService.java
@@ -14,7 +14,6 @@ import gov.cabinetofice.gapuserservice.config.ApplicationConfigProperties;
 import gov.cabinetofice.gapuserservice.dto.*;
 import gov.cabinetofice.gapuserservice.enums.LoginJourneyState;
 import gov.cabinetofice.gapuserservice.exceptions.*;
-import gov.cabinetofice.gapuserservice.mappers.RoleMapper;
 import gov.cabinetofice.gapuserservice.model.Nonce;
 import gov.cabinetofice.gapuserservice.model.Role;
 import gov.cabinetofice.gapuserservice.model.RoleEnum;
@@ -97,7 +96,6 @@ public class OneLoginService {
     private final JwtBlacklistService jwtBlacklistService;
     private final CustomJwtServiceImpl customJwtService;
     private final OneLoginUserService oneLoginUserService;
-    private final RoleMapper roleMapper;
 
     public PrivateKey parsePrivateKey() {
         try {

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/OneLoginService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/OneLoginService.java
@@ -44,7 +44,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.servlet.view.RedirectView;
 
-
 import java.io.IOException;
 import java.net.URL;
 import java.security.KeyFactory;
@@ -396,19 +395,5 @@ public class OneLoginService {
         );
     }
 
-    public void validateAdminSession(String emailAddress, String roles) throws UnauthorizedException {
-        final List<Role> userRoles = userRepository.findByEmailAddress(emailAddress).get().getRoles();
-
-        final boolean sameNumberOfRoles = roles.split(",").length == userRoles.size();
-
-        if(!sameNumberOfRoles){
-            throw new UnauthorizedException("Roles in payload do not match roles in database");
-        }
-
-        final boolean allRolesMatch = userRoles.stream().allMatch(role -> roles.contains(roleMapper.roleToRoleDto(role).getName()));
-        if(!allRolesMatch){
-            throw new UnauthorizedException("Roles in payload do not match roles in database");
-        }
-    }
 }
 

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/jwt/impl/CustomJwtServiceImpl.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/jwt/impl/CustomJwtServiceImpl.java
@@ -168,7 +168,7 @@ public class CustomJwtServiceImpl implements JwtService {
         }
         final DecodedJWT decodedJwt = decodedJwt(customJWTCookie.getValue());
         final JwtPayload payload = decodeTheTokenPayloadInAReadableFormat(decodedJwt);
-        return  userRepository.findBySub(payload.getSub());
+        return userRepository.findBySub(payload.getSub());
     }
 
     public JwtPayload validateRolesInThePayload(JwtPayload payload) throws UnauthorizedException {

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/jwt/impl/CustomJwtServiceImpl.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/jwt/impl/CustomJwtServiceImpl.java
@@ -53,7 +53,13 @@ public class CustomJwtServiceImpl implements JwtService {
     @Value("${feature.onelogin.enabled}")
     public boolean oneLoginEnabled;
 
-    public CustomJwtServiceImpl(OneLoginUserService oneLoginUserService, JwtProperties jwtProperties, JwtBlacklistRepository jwtBlacklistRepository, UserRepository userRepository, Clock clock) throws JOSEException {
+    @Value("${feature.validate-user-roles-in-middleware}")
+    public boolean validateUserRolesInMiddleware;
+
+
+    public CustomJwtServiceImpl(OneLoginUserService oneLoginUserService,
+                                JwtProperties jwtProperties, JwtBlacklistRepository jwtBlacklistRepository,
+                                UserRepository userRepository, Clock clock) throws JOSEException {
         this.oneLoginUserService = oneLoginUserService;
         this.jwtProperties = jwtProperties;
         this.jwtBlacklistRepository = jwtBlacklistRepository;
@@ -86,7 +92,9 @@ public class CustomJwtServiceImpl implements JwtService {
                 Optional<User> user = userRepository.findBySub(jwtPayload.getSub());
                 if (user.isEmpty()) user = userRepository.findByEmailAddress(jwtPayload.getEmail());
                 if (user.isEmpty()) return false;
-                validateRolesInThePayload(jwtPayload);
+                if(validateUserRolesInMiddleware){
+                    validateRolesInThePayload(jwtPayload);
+                }
                 if (user.get().getLoginJourneyState().equals(LoginJourneyState.PRIVACY_POLICY_PENDING)) return false;
             }
 

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/jwt/impl/CustomJwtServiceImpl.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/jwt/impl/CustomJwtServiceImpl.java
@@ -171,7 +171,7 @@ public class CustomJwtServiceImpl implements JwtService {
         return userRepository.findBySub(payload.getSub());
     }
 
-    public JwtPayload validateRolesInThePayload(JwtPayload payload) throws UnauthorizedException {
+    public JwtPayload validateRolesInThePayload(JwtPayload payload) {
         final List<Role> userRoles = oneLoginUserService.getUserBySub(payload.getSub()).getRoles();
         final String payloadRoles = payload.getRoles();
         oneLoginUserService.validateRoles(userRoles, payloadRoles);

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/jwt/impl/CustomJwtServiceImpl.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/jwt/impl/CustomJwtServiceImpl.java
@@ -172,9 +172,9 @@ public class CustomJwtServiceImpl implements JwtService {
     }
 
     public JwtPayload validateRolesInThePayload(JwtPayload payload) throws UnauthorizedException {
-        final List<Role> dbRoles = oneLoginUserService.getUserBySub(payload.getSub()).getRoles();
-        final String roles = payload.getRoles();
-        oneLoginUserService.validateRoles(dbRoles, roles);
+        final List<Role> userRoles = oneLoginUserService.getUserBySub(payload.getSub()).getRoles();
+        final String payloadRoles = payload.getRoles();
+        oneLoginUserService.validateRoles(userRoles, payloadRoles);
         return payload;
     }
 

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/jwt/impl/CustomJwtServiceImpl.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/jwt/impl/CustomJwtServiceImpl.java
@@ -1,10 +1,10 @@
 package gov.cabinetofice.gapuserservice.service.jwt.impl;
 
 import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import com.auth0.jwt.interfaces.JWTVerifier;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.KeyUse;
@@ -13,23 +13,27 @@ import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import gov.cabinetofice.gapuserservice.config.JwtProperties;
 import gov.cabinetofice.gapuserservice.dto.JwtPayload;
 import gov.cabinetofice.gapuserservice.enums.LoginJourneyState;
+import gov.cabinetofice.gapuserservice.exceptions.UnauthorizedException;
+import gov.cabinetofice.gapuserservice.mappers.RoleMapper;
+import gov.cabinetofice.gapuserservice.model.Role;
 import gov.cabinetofice.gapuserservice.model.User;
 import gov.cabinetofice.gapuserservice.repository.JwtBlacklistRepository;
 import gov.cabinetofice.gapuserservice.repository.UserRepository;
 import gov.cabinetofice.gapuserservice.service.jwt.JwtService;
+import gov.cabinetofice.gapuserservice.service.user.OneLoginUserService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.tomcat.util.codec.binary.Base64;
 import org.apache.tomcat.util.codec.binary.StringUtils;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.WebUtils;
 
 import java.time.Clock;
 import java.time.ZonedDateTime;
-import java.util.Date;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 @Service
 @Slf4j
@@ -39,13 +43,20 @@ public class CustomJwtServiceImpl implements JwtService {
     private final JwtBlacklistRepository jwtBlacklistRepository;
 
     private final UserRepository userRepository;
+    private final OneLoginUserService oneLoginUserService;
+    private final RoleMapper roleMapper;
     private final Clock clock;
     private final RSAKey rsaKey;
+
+    @Value("${jwt.cookie-name}")
+    public String userServiceCookieName;
 
     @Value("${feature.onelogin.enabled}")
     public boolean oneLoginEnabled;
 
-    public CustomJwtServiceImpl(JwtProperties jwtProperties, JwtBlacklistRepository jwtBlacklistRepository, UserRepository userRepository, Clock clock) throws JOSEException {
+    public CustomJwtServiceImpl(RoleMapper roleMapper, OneLoginUserService oneLoginUserService, JwtProperties jwtProperties, JwtBlacklistRepository jwtBlacklistRepository, UserRepository userRepository, Clock clock) throws JOSEException {
+        this.roleMapper = roleMapper;
+        this.oneLoginUserService = oneLoginUserService;
         this.jwtProperties = jwtProperties;
         this.jwtBlacklistRepository = jwtBlacklistRepository;
         this.userRepository = userRepository;
@@ -77,6 +88,7 @@ public class CustomJwtServiceImpl implements JwtService {
                 Optional<User> user = userRepository.findBySub(jwtPayload.getSub());
                 if (user.isEmpty()) user = userRepository.findByEmailAddress(jwtPayload.getEmail());
                 if (user.isEmpty()) return false;
+                verifyThatRolesInPayloadMatchRolesInDB(jwtPayload);
                 if (user.get().getLoginJourneyState().equals(LoginJourneyState.PRIVACY_POLICY_PENDING)) return false;
             }
 
@@ -87,6 +99,9 @@ public class CustomJwtServiceImpl implements JwtService {
         } catch (JOSEException exception) {
             log.error("isTokenValid failed", exception);
             throw new RuntimeException(exception);
+        } catch (UnauthorizedException exception) {
+            log.error("JWT payload verification failed", exception);
+            return false;
         }
     }
 
@@ -146,5 +161,31 @@ public class CustomJwtServiceImpl implements JwtService {
                 .iat(iat)
                 .email(email)
                 .build();
+    }
+
+    public User getUserFromJwt(final HttpServletRequest request) {
+        final Cookie customJWTCookie = WebUtils.getCookie(request, userServiceCookieName);
+        if (customJWTCookie == null || customJWTCookie.getValue() == null) {
+            throw new UnauthorizedException("No JWT token provided");
+        }
+        final DecodedJWT decodedJwt = decodedJwt(customJWTCookie.getValue());
+        final JwtPayload payload = decodeTheTokenPayloadInAReadableFormat(decodedJwt);
+        return  userRepository.findBySub(payload.getSub()).get();
+    }
+
+    public JwtPayload verifyThatRolesInPayloadMatchRolesInDB(JwtPayload payload) throws UnauthorizedException {
+        final List<Role> userRoles = oneLoginUserService.getUserBySub(payload.getSub()).getRoles();
+
+        final boolean sameNumberOfRoles = payload.getRoles().split(",").length == userRoles.size();
+
+        if(!sameNumberOfRoles){
+            throw new UnauthorizedException("Roles in payload do not match roles in database");
+        }
+
+        final boolean allRolesMatch = userRoles.stream().allMatch(role -> payload.getRoles().contains(roleMapper.roleToRoleDto(role).getName()));
+        if(!allRolesMatch){
+            throw new UnauthorizedException("Roles in payload do not match roles in database");
+        }
+        return payload;
     }
 }

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/jwt/impl/CustomJwtServiceImpl.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/jwt/impl/CustomJwtServiceImpl.java
@@ -161,14 +161,14 @@ public class CustomJwtServiceImpl implements JwtService {
                 .build();
     }
 
-    public User getUserFromJwt(final HttpServletRequest request) {
+    public Optional<User> getUserFromJwt(final HttpServletRequest request) {
         final Cookie customJWTCookie = WebUtils.getCookie(request, userServiceCookieName);
         if (customJWTCookie == null || customJWTCookie.getValue() == null) {
             throw new UnauthorizedException("No JWT token provided");
         }
         final DecodedJWT decodedJwt = decodedJwt(customJWTCookie.getValue());
         final JwtPayload payload = decodeTheTokenPayloadInAReadableFormat(decodedJwt);
-        return  userRepository.findBySub(payload.getSub()).get();
+        return  userRepository.findBySub(payload.getSub());
     }
 
     public JwtPayload validateRolesInThePayload(JwtPayload payload) throws UnauthorizedException {
@@ -177,5 +177,4 @@ public class CustomJwtServiceImpl implements JwtService {
         oneLoginUserService.validateRoles(userRoles, payloadRoles);
         return payload;
     }
-
 }

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/jwt/impl/CustomJwtServiceImpl.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/jwt/impl/CustomJwtServiceImpl.java
@@ -14,7 +14,6 @@ import gov.cabinetofice.gapuserservice.config.JwtProperties;
 import gov.cabinetofice.gapuserservice.dto.JwtPayload;
 import gov.cabinetofice.gapuserservice.enums.LoginJourneyState;
 import gov.cabinetofice.gapuserservice.exceptions.UnauthorizedException;
-import gov.cabinetofice.gapuserservice.mappers.RoleMapper;
 import gov.cabinetofice.gapuserservice.model.Role;
 import gov.cabinetofice.gapuserservice.model.User;
 import gov.cabinetofice.gapuserservice.repository.JwtBlacklistRepository;
@@ -45,7 +44,6 @@ public class CustomJwtServiceImpl implements JwtService {
     private final UserRepository userRepository;
     private final OneLoginUserService oneLoginUserService;
 
-    private final RoleMapper roleMapper;
     private final Clock clock;
     private final RSAKey rsaKey;
 
@@ -55,8 +53,7 @@ public class CustomJwtServiceImpl implements JwtService {
     @Value("${feature.onelogin.enabled}")
     public boolean oneLoginEnabled;
 
-    public CustomJwtServiceImpl(RoleMapper roleMapper, OneLoginUserService oneLoginUserService, JwtProperties jwtProperties, JwtBlacklistRepository jwtBlacklistRepository, UserRepository userRepository, Clock clock) throws JOSEException {
-        this.roleMapper = roleMapper;
+    public CustomJwtServiceImpl(OneLoginUserService oneLoginUserService, JwtProperties jwtProperties, JwtBlacklistRepository jwtBlacklistRepository, UserRepository userRepository, Clock clock) throws JOSEException {
         this.oneLoginUserService = oneLoginUserService;
         this.jwtProperties = jwtProperties;
         this.jwtBlacklistRepository = jwtBlacklistRepository;

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
@@ -29,7 +29,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.*;
 import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 
 import static gov.cabinetofice.gapuserservice.util.HelperUtils.removeSquareBracketsAndTrim;
 
@@ -177,11 +176,11 @@ public class OneLoginUserService {
         response.addCookie(thirdPartyAuthToken);
     }
 
-    public void validateRoles(List<Role> dbRoles, String roles) {
-        final List<String> rolesList = removeSquareBracketsAndTrim(Arrays.asList(roles.split(",")));
-        final List<String> dbRolesList = dbRoles.stream().map(role -> roleMapper.roleToRoleDto(role).getName()).collect(Collectors.toList());
+    public void validateRoles(List<Role> userRoles, String payloadRoles) {
+        final List<String> formattedPayloadRoles = removeSquareBracketsAndTrim(Arrays.asList(payloadRoles.split(",")));
+        final List<String> formattedUserRoles = userRoles.stream().map(role -> roleMapper.roleToRoleDto(role).getName()).toList();
 
-        if(!new HashSet<>(dbRolesList).containsAll(rolesList)){
+        if(!new HashSet<>(formattedPayloadRoles).containsAll(formattedUserRoles)){
             throw new UnauthorizedException("Roles in payload do not match roles in database");
         }
     }

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
@@ -1,5 +1,3 @@
-
-
 package gov.cabinetofice.gapuserservice.service.user;
 
 import gov.cabinetofice.gapuserservice.config.ApplicationConfigProperties;

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
@@ -205,7 +205,7 @@ public class OneLoginUserService {
         }
     }
 
-    public void validateAdminSession(String emailAddress, String roles) throws InvalidRequestException {
+    public void validateSessionsRoles(String emailAddress, String roles) throws InvalidRequestException {
         Optional<User> user = userRepository.findByEmailAddress(emailAddress);
         if(user.isEmpty()){
             throw new InvalidRequestException("Could not get user from emailAddress");

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.*;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 import static gov.cabinetofice.gapuserservice.util.HelperUtils.removeSquareBracketsAndTrim;
 
@@ -196,10 +197,11 @@ public class OneLoginUserService {
 
     public void validateRoles(List<Role> userRoles, String payloadRoles) throws UnauthorizedException {
         final List<String> formattedPayloadRoles = removeSquareBracketsAndTrim(Arrays.asList(payloadRoles.split(",")));
-        final List<String> formattedUserRoles = userRoles.stream().map(role -> roleMapper.roleToRoleDto(role).getName()).toList();
-        HashSet userStoredRoles = new HashSet<>(formattedUserRoles);
+        final Set<String> formattedUserRoles = userRoles.stream()
+                .map(role -> roleMapper.roleToRoleDto(role).getName())
+                .collect(Collectors.toSet());
 
-        if(!userStoredRoles.containsAll(formattedPayloadRoles)){
+        if(!formattedUserRoles.containsAll(formattedPayloadRoles)){
             throw new UnauthorizedException("Roles in payload do not match roles in database");
         }
     }

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
@@ -198,8 +198,9 @@ public class OneLoginUserService {
         final Set<String> formattedUserRoles = userRoles.stream()
                 .map(role -> roleMapper.roleToRoleDto(role).getName())
                 .collect(Collectors.toSet());
+        final boolean rolesAreValid = formattedUserRoles.containsAll(formattedPayloadRoles) && formattedPayloadRoles.containsAll(formattedUserRoles);
 
-        if(!formattedUserRoles.containsAll(formattedPayloadRoles)){
+        if(!rolesAreValid){
             throw new UnauthorizedException("Roles in payload do not match roles in database");
         }
     }

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
@@ -1,3 +1,5 @@
+
+
 package gov.cabinetofice.gapuserservice.service.user;
 
 import gov.cabinetofice.gapuserservice.config.ApplicationConfigProperties;
@@ -67,6 +69,10 @@ public class OneLoginUserService {
     public User getUserById(int id) {
         return userRepository.findById(id)
                 .orElseThrow(() -> new UserNotFoundException("user with id: " + id + "not found"));
+    }
+    public User getUserBySub(String sub) {
+        return userRepository.findBySub(sub)
+                .orElseThrow(() -> new UserNotFoundException("user with sub: " + sub + "not found"));
     }
 
     public User updateDepartment(Integer id, Integer departmentId) {

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
@@ -176,7 +176,7 @@ public class OneLoginUserService {
         response.addCookie(thirdPartyAuthToken);
     }
 
-    public void validateRoles(List<Role> userRoles, String payloadRoles) {
+    public void validateRoles(List<Role> userRoles, String payloadRoles) throws UnauthorizedException {
         final List<String> formattedPayloadRoles = removeSquareBracketsAndTrim(Arrays.asList(payloadRoles.split(",")));
         final List<String> formattedUserRoles = userRoles.stream().map(role -> roleMapper.roleToRoleDto(role).getName()).toList();
         HashSet userStoredRoles = new HashSet<>(formattedUserRoles);

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
@@ -192,7 +192,7 @@ public class OneLoginUserService {
         response.addCookie(thirdPartyAuthToken);
     }
 
-    public void validateRoles(List<Role> userRoles, String payloadRoles) throws UnauthorizedException {
+    public void validateRoles(List<Role> userRoles, String payloadRoles) {
         final Set<String> formattedPayloadRoles = removeSquareBracketsAndTrim(Arrays.asList(payloadRoles
                 .split(",")));
         final Set<String> formattedUserRoles = userRoles.stream()
@@ -205,7 +205,7 @@ public class OneLoginUserService {
         }
     }
 
-    public void validateSessionsRoles(String emailAddress, String roles) throws InvalidRequestException {
+    public void validateSessionsRoles(String emailAddress, String roles) {
         List<Role> userRoles = userRepository.findByEmailAddress(emailAddress).orElseThrow(() -> new InvalidRequestException("Could not get user from emailAddress")).getRoles();
         validateRoles(userRoles, roles);
     }

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
@@ -179,8 +179,9 @@ public class OneLoginUserService {
     public void validateRoles(List<Role> userRoles, String payloadRoles) {
         final List<String> formattedPayloadRoles = removeSquareBracketsAndTrim(Arrays.asList(payloadRoles.split(",")));
         final List<String> formattedUserRoles = userRoles.stream().map(role -> roleMapper.roleToRoleDto(role).getName()).toList();
+        HashSet userStoredRoles = new HashSet<>(formattedUserRoles);
 
-        if(!new HashSet<>(formattedPayloadRoles).containsAll(formattedUserRoles)){
+        if(!userStoredRoles.containsAll(formattedPayloadRoles)){
             throw new UnauthorizedException("Roles in payload do not match roles in database");
         }
     }

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
@@ -206,11 +206,7 @@ public class OneLoginUserService {
     }
 
     public void validateSessionsRoles(String emailAddress, String roles) throws InvalidRequestException {
-        Optional<User> user = userRepository.findByEmailAddress(emailAddress);
-        if(user.isEmpty()){
-            throw new InvalidRequestException("Could not get user from emailAddress");
-        }
-        final List<Role> userRoles = user.get().getRoles();
+        List<Role> userRoles = userRepository.findByEmailAddress(emailAddress).orElseThrow(() -> new InvalidRequestException("Could not get user from emailAddress")).getRoles();
         validateRoles(userRoles, roles);
     }
 }

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
@@ -193,12 +193,12 @@ public class OneLoginUserService {
     }
 
     public void validateRoles(List<Role> userRoles, String payloadRoles) throws UnauthorizedException {
-        final List<String> formattedPayloadRoles = removeSquareBracketsAndTrim(Arrays.asList(payloadRoles
+        final Set<String> formattedPayloadRoles = removeSquareBracketsAndTrim(Arrays.asList(payloadRoles
                 .split(",")));
         final Set<String> formattedUserRoles = userRoles.stream()
                 .map(role -> roleMapper.roleToRoleDto(role).getName())
                 .collect(Collectors.toSet());
-        final boolean rolesAreValid = formattedUserRoles.containsAll(formattedPayloadRoles) && formattedPayloadRoles.containsAll(formattedUserRoles);
+        final boolean rolesAreValid = formattedPayloadRoles.equals(formattedUserRoles);
 
         if(!rolesAreValid){
             throw new UnauthorizedException("Roles in payload do not match roles in database");

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserService.java
@@ -3,10 +3,7 @@ package gov.cabinetofice.gapuserservice.service.user;
 import gov.cabinetofice.gapuserservice.config.ApplicationConfigProperties;
 import gov.cabinetofice.gapuserservice.config.ThirdPartyAuthProviderProperties;
 import gov.cabinetofice.gapuserservice.dto.UserQueryDto;
-import gov.cabinetofice.gapuserservice.exceptions.DepartmentNotFoundException;
-import gov.cabinetofice.gapuserservice.exceptions.RoleNotFoundException;
-import gov.cabinetofice.gapuserservice.exceptions.UnauthorizedException;
-import gov.cabinetofice.gapuserservice.exceptions.UserNotFoundException;
+import gov.cabinetofice.gapuserservice.exceptions.*;
 import gov.cabinetofice.gapuserservice.mappers.RoleMapper;
 import gov.cabinetofice.gapuserservice.model.Department;
 import gov.cabinetofice.gapuserservice.model.Role;
@@ -196,7 +193,8 @@ public class OneLoginUserService {
     }
 
     public void validateRoles(List<Role> userRoles, String payloadRoles) throws UnauthorizedException {
-        final List<String> formattedPayloadRoles = removeSquareBracketsAndTrim(Arrays.asList(payloadRoles.split(",")));
+        final List<String> formattedPayloadRoles = removeSquareBracketsAndTrim(Arrays.asList(payloadRoles
+                .split(",")));
         final Set<String> formattedUserRoles = userRoles.stream()
                 .map(role -> roleMapper.roleToRoleDto(role).getName())
                 .collect(Collectors.toSet());
@@ -206,8 +204,12 @@ public class OneLoginUserService {
         }
     }
 
-    public void validateAdminSession(String emailAddress, String roles) throws UnauthorizedException {
-        final List<Role> dbRoles = userRepository.findByEmailAddress(emailAddress).get().getRoles();
-        validateRoles(dbRoles, roles);
+    public void validateAdminSession(String emailAddress, String roles) throws InvalidRequestException {
+        Optional<User> user = userRepository.findByEmailAddress(emailAddress);
+        if(user.isEmpty()){
+            throw new InvalidRequestException("Could not get user from emailAddress");
+        }
+        final List<Role> userRoles = user.get().getRoles();
+        validateRoles(userRoles, roles);
     }
 }

--- a/src/main/java/gov/cabinetofice/gapuserservice/util/HelperUtils.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/util/HelperUtils.java
@@ -8,9 +8,9 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.security.SecureRandom;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class HelperUtils {
 
@@ -60,12 +60,9 @@ public class HelperUtils {
     }
 
     public static List<String> removeSquareBracketsAndTrim(List<String> inputList) {
-        List<String> cleanedList = new ArrayList<>();
-        for (String input : inputList) {
-            String cleanedString = input.replace("[", "").replace("]", "");
-            cleanedList.add(cleanedString.trim());
-        }
-        return cleanedList;
+        return inputList.stream()
+                .map(input -> input.replace("[", "").replace("]", "").trim())
+                .collect(Collectors.toList());
     }
 
     public static String generateSecureRandomString(final Integer strLen) {

--- a/src/main/java/gov/cabinetofice/gapuserservice/util/HelperUtils.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/util/HelperUtils.java
@@ -8,6 +8,8 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 public class HelperUtils {
@@ -55,6 +57,15 @@ public class HelperUtils {
         catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static List<String> removeSquareBracketsAndTrim(List<String> inputList) {
+        List<String> cleanedList = new ArrayList<>();
+        for (String input : inputList) {
+            String cleanedString = input.replace("[", "").replace("]", "");
+            cleanedList.add(cleanedString.trim());
+        }
+        return cleanedList;
     }
 
     public static String generateSecureRandomString(final Integer strLen) {

--- a/src/main/java/gov/cabinetofice/gapuserservice/util/HelperUtils.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/util/HelperUtils.java
@@ -10,6 +10,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.security.SecureRandom;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class HelperUtils {
@@ -59,10 +60,10 @@ public class HelperUtils {
         }
     }
 
-    public static List<String> removeSquareBracketsAndTrim(List<String> inputList) {
+    public static Set<String> removeSquareBracketsAndTrim(List<String> inputList) {
         return inputList.stream()
                 .map(input -> input.replace("[", "").replace("]", "").trim())
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
     }
 
     public static String generateSecureRandomString(final Integer strLen) {

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
@@ -84,7 +84,8 @@ public class LoginControllerV2 {
     public String migrationEnabled;
 
     @GetMapping("/validateSessionsRoles")
-    public ResponseEntity<Boolean> validateSessionsRoles(@RequestParam("emailAddress") String emailAddress, @RequestParam("roles") String roles){
+    public ResponseEntity<Boolean> validateSessionsRoles(@RequestParam("emailAddress") String emailAddress,
+                                                         @RequestParam("roles") String roles){
         oneLoginUserService.validateSessionsRoles(emailAddress, roles);
         return ResponseEntity.ok(Boolean.TRUE);
     }

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
@@ -82,7 +82,7 @@ public class LoginControllerV2 {
     public String migrationEnabled;
 
     @GetMapping("/validateAdminSession")
-    public ResponseEntity<Boolean> validateAdminRoles(@RequestHeader("emailaddress") String emailAddress, @RequestHeader("roles") String roles){
+    public ResponseEntity<Boolean> validateAdminRoles(@RequestParam("emailAddress") String emailAddress, @RequestParam("roles") String roles){
         oneLoginUserService.validateAdminSession(emailAddress, roles);
         return ResponseEntity.ok(Boolean.TRUE);
     }

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
@@ -4,7 +4,6 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import gov.cabinetofice.gapuserservice.config.ApplicationConfigProperties;
 import gov.cabinetofice.gapuserservice.config.FindAGrantConfigProperties;
-import gov.cabinetofice.gapuserservice.dto.IdTokenDto;
 import gov.cabinetofice.gapuserservice.dto.OneLoginUserInfoDto;
 import gov.cabinetofice.gapuserservice.dto.PrivacyPolicyDto;
 import gov.cabinetofice.gapuserservice.dto.StateCookieDto;
@@ -14,6 +13,7 @@ import gov.cabinetofice.gapuserservice.model.Nonce;
 import gov.cabinetofice.gapuserservice.model.User;
 import gov.cabinetofice.gapuserservice.repository.NonceRepository;
 import gov.cabinetofice.gapuserservice.service.OneLoginService;
+import gov.cabinetofice.gapuserservice.service.RoleService;
 import gov.cabinetofice.gapuserservice.service.encryption.Sha512Service;
 import gov.cabinetofice.gapuserservice.service.jwt.impl.CustomJwtServiceImpl;
 import gov.cabinetofice.gapuserservice.util.WebUtil;
@@ -27,6 +27,7 @@ import lombok.extern.log4j.Log4j2;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
@@ -47,6 +48,7 @@ import java.util.Optional;
 @Getter
 public class LoginControllerV2 {
     private final OneLoginService oneLoginService;
+    private final RoleService roleService;
     private final CustomJwtServiceImpl customJwtService;
     private final ApplicationConfigProperties configProperties;
     private final Sha512Service encryptionService;
@@ -75,6 +77,11 @@ public class LoginControllerV2 {
     @Value("${feature.onelogin.migration.enabled}")
     public String migrationEnabled;
 
+    @GetMapping("/verifyAdminSession")
+    public ResponseEntity<Boolean> verifyAdminRoles(@RequestHeader("emailaddress") String emailAddress, @RequestHeader("roles") String roles){
+        oneLoginService.validateAdminSession(emailAddress, roles);
+        return ResponseEntity.ok(Boolean.TRUE);
+    }
     @GetMapping("/login")
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     public RedirectView login(final @RequestParam(name = REDIRECT_URL_NAME) Optional<String> redirectUrlParam,

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
@@ -6,6 +6,7 @@ import gov.cabinetofice.gapuserservice.config.ApplicationConfigProperties;
 import gov.cabinetofice.gapuserservice.config.FindAGrantConfigProperties;
 import gov.cabinetofice.gapuserservice.dto.OneLoginUserInfoDto;
 import gov.cabinetofice.gapuserservice.dto.PrivacyPolicyDto;
+import gov.cabinetofice.gapuserservice.dto.IdTokenDto;
 import gov.cabinetofice.gapuserservice.dto.StateCookieDto;
 import gov.cabinetofice.gapuserservice.exceptions.UnauthorizedException;
 import gov.cabinetofice.gapuserservice.exceptions.UserNotFoundException;

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
@@ -83,9 +83,9 @@ public class LoginControllerV2 {
     @Value("${feature.onelogin.migration.enabled}")
     public String migrationEnabled;
 
-    @GetMapping("/validateAdminSession")
-    public ResponseEntity<Boolean> validateAdminRoles(@RequestParam("emailAddress") String emailAddress, @RequestParam("roles") String roles){
-        oneLoginUserService.validateAdminSession(emailAddress, roles);
+    @GetMapping("/validateSessionsRoles")
+    public ResponseEntity<Boolean> validateSessionsRoles(@RequestParam("emailAddress") String emailAddress, @RequestParam("roles") String roles){
+        oneLoginUserService.validateSessionsRoles(emailAddress, roles);
         return ResponseEntity.ok(Boolean.TRUE);
     }
 

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2.java
@@ -17,6 +17,7 @@ import gov.cabinetofice.gapuserservice.service.OneLoginService;
 import gov.cabinetofice.gapuserservice.service.RoleService;
 import gov.cabinetofice.gapuserservice.service.encryption.Sha512Service;
 import gov.cabinetofice.gapuserservice.service.jwt.impl.CustomJwtServiceImpl;
+import gov.cabinetofice.gapuserservice.service.user.OneLoginUserService;
 import gov.cabinetofice.gapuserservice.util.WebUtil;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -54,6 +55,8 @@ public class LoginControllerV2 {
     private final ApplicationConfigProperties configProperties;
     private final Sha512Service encryptionService;
     private final NonceRepository nonceRepository;
+    private final OneLoginUserService oneLoginUserService;
+
 
     private final FindAGrantConfigProperties findProperties;
 
@@ -78,11 +81,12 @@ public class LoginControllerV2 {
     @Value("${feature.onelogin.migration.enabled}")
     public String migrationEnabled;
 
-    @GetMapping("/verifyAdminSession")
-    public ResponseEntity<Boolean> verifyAdminRoles(@RequestHeader("emailaddress") String emailAddress, @RequestHeader("roles") String roles){
-        oneLoginService.validateAdminSession(emailAddress, roles);
+    @GetMapping("/validateAdminSession")
+    public ResponseEntity<Boolean> validateAdminRoles(@RequestHeader("emailaddress") String emailAddress, @RequestHeader("roles") String roles){
+        oneLoginUserService.validateAdminSession(emailAddress, roles);
         return ResponseEntity.ok(Boolean.TRUE);
     }
+
     @GetMapping("/login")
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     public RedirectView login(final @RequestParam(name = REDIRECT_URL_NAME) Optional<String> redirectUrlParam,

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/UserController.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/UserController.java
@@ -110,13 +110,13 @@ public class UserController {
             throw new ForbiddenException();
         }
 
-        boolean requestToBlockUser = roleIds.size() == 0;
+        boolean isARequestToBlockUser = roleIds.size() == 0;
         Optional<User> user = jwtService.getUserFromJwt(httpRequest);
 
         if(user.isEmpty()){
             throw new InvalidRequestException("Could not get user from jwt");
         }
-        if (requestToBlockUser && id.equals(user.get().getGapUserId())){
+        if (isARequestToBlockUser && id.equals(user.get().getGapUserId())){
             throw new UnsupportedOperationException("You can't block yourself");
         }
 

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/UserController.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/UserController.java
@@ -7,6 +7,7 @@ import gov.cabinetofice.gapuserservice.exceptions.ForbiddenException;
 import gov.cabinetofice.gapuserservice.model.User;
 import gov.cabinetofice.gapuserservice.service.DepartmentService;
 import gov.cabinetofice.gapuserservice.service.RoleService;
+import gov.cabinetofice.gapuserservice.service.jwt.impl.CustomJwtServiceImpl;
 import gov.cabinetofice.gapuserservice.service.user.OneLoginUserService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,16 @@ public class UserController {
     private final OneLoginUserService oneLoginUserService;
     private final DepartmentService departmentService;
     private final RoleService roleService;
+    private final CustomJwtServiceImpl jwtService;
+
+    @GetMapping("/user")
+    public ResponseEntity<User> getUserFromJwt(HttpServletRequest httpRequest) {
+        if (!roleService.isSuperAdmin(httpRequest)) {
+            throw new ForbiddenException();
+        }
+
+        return ResponseEntity.ok(jwtService.getUserFromJwt(httpRequest));
+    }
 
     @GetMapping("/isSuperAdmin")
     public ResponseEntity<String> isSuperAdmin(HttpServletRequest httpRequest) {
@@ -88,5 +99,7 @@ public class UserController {
 
         oneLoginUserService.deleteUser(id);
         return ResponseEntity.ok("success");
+
     }
 }
+

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/UserController.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/UserController.java
@@ -32,7 +32,7 @@ public class UserController {
     private final CustomJwtServiceImpl jwtService;
     private final SecretAuthService secretAuthService;
 
-    @GetMapping("/user")
+    @GetMapping("/userFromJwt")
     public ResponseEntity<UserDto> getUserFromJwt(HttpServletRequest httpRequest) {
         if (!roleService.isSuperAdmin(httpRequest)) {
             throw new ForbiddenException();

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/UserController.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/UserController.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Optional;
 
 
 @RequiredArgsConstructor
@@ -38,8 +39,12 @@ public class UserController {
         if (!roleService.isSuperAdmin(httpRequest)) {
             throw new ForbiddenException();
         }
+        Optional<User> user = jwtService.getUserFromJwt(httpRequest);
+        if(user.isEmpty()){
+            throw new InvalidRequestException("Could not get user from jwt");
+        }
 
-        return ResponseEntity.ok(new UserDto(jwtService.getUserFromJwt(httpRequest)));
+        return ResponseEntity.ok(new UserDto(user.get()));
     }
 
     @GetMapping("/isSuperAdmin")
@@ -106,8 +111,12 @@ public class UserController {
         }
 
         boolean requestToBlockUser = roleIds.size() == 0;
+        Optional<User> user = jwtService.getUserFromJwt(httpRequest);
 
-        if (requestToBlockUser && id == jwtService.getUserFromJwt(httpRequest).getGapUserId()){
+        if(user.isEmpty()){
+            throw new InvalidRequestException("Could not get user from jwt");
+        }
+        if (requestToBlockUser && id.equals(user.get().getGapUserId())){
             throw new UnsupportedOperationException("You can't block yourself");
         }
 
@@ -120,8 +129,11 @@ public class UserController {
         if (!roleService.isSuperAdmin(httpRequest)) {
             throw new ForbiddenException();
         }
-
-        if(jwtService.getUserFromJwt(httpRequest).getGapUserId() == id) {
+        Optional<User> user = jwtService.getUserFromJwt(httpRequest);
+        if(user.isEmpty()){
+            throw new InvalidRequestException("Could not get user from jwt");
+        }
+        if(user.get().getGapUserId().equals(id)) {
             throw new UnsupportedOperationException("You can't delete yourself");
         }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -55,6 +55,7 @@ onelogin.service-redirect-url=redirectUrlValue
 onelogin.private-key=privateKeyValue
 feature.onelogin.enabled=false
 feature.onelogin.migration.enabled=false
+feature.validate-user-roles-in-middleware=true
 onelogin.logout-url=http://localhost:8888/logout
 onelogin.post-logout-redirect-uri=example
 

--- a/src/test/java/gov/cabinetofice/gapuserservice/service/jwt/CustomJwtServiceImplTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/service/jwt/CustomJwtServiceImplTest.java
@@ -79,7 +79,8 @@ public class CustomJwtServiceImplTest {
                 .audience("test-audience")
                 .expiresAfter(60)
                 .build();
-        serviceUnderTest = spy(new CustomJwtServiceImpl(oneLoginUserService, jwtProperties, jwtBlacklistRepository, userRepository, clock));
+        serviceUnderTest = spy(new CustomJwtServiceImpl(
+                oneLoginUserService, jwtProperties, jwtBlacklistRepository, userRepository, clock));
         ReflectionTestUtils.setField(serviceUnderTest, "userServiceCookieName", "userServiceCookieName");
     }
 
@@ -153,7 +154,11 @@ public class CustomJwtServiceImplTest {
                     staticJwt.when(() -> require(any())).thenReturn(spiedVerification);
                     staticJwt.when(() -> decode(any())).thenCallRealMethod();
                     when(spiedVerification.build()).thenReturn(mockedJwtVerifier);
-                    User testUser = User.builder().roles(List.of(Role.builder().name(RoleEnum.FIND).id(1).build(), Role.builder().name(RoleEnum.SUPER_ADMIN).id(4).build(), Role.builder().name(RoleEnum.ADMIN).id(3).build(), Role.builder().name(RoleEnum.APPLICANT).id(2).build())).loginJourneyState(LoginJourneyState.USER_READY).build();
+                    User testUser = User.builder().roles(List.of(Role.builder().name(RoleEnum.FIND).id(1).build(),
+                            Role.builder().name(RoleEnum.SUPER_ADMIN).id(4).build(),
+                            Role.builder().name(RoleEnum.ADMIN).id(3).build(),
+                            Role.builder().name(RoleEnum.APPLICANT).id(2).build()))
+                            .loginJourneyState(LoginJourneyState.USER_READY).build();
                     when(userRepository.findBySub(any())).thenReturn(Optional.of(testUser));
                     when(oneLoginUserService.getUserBySub(any())).thenReturn(testUser);
                     doThrow(UnauthorizedException.class).when(oneLoginUserService).validateRoles(any(), any());
@@ -178,7 +183,11 @@ public class CustomJwtServiceImplTest {
                     staticJwt.when(() -> decode(any())).thenCallRealMethod();
                     when(spiedVerification.build()).thenReturn(mockedJwtVerifier);
                     when(jwtBlacklistRepository.existsByJwtIs(jwt)).thenReturn(true);
-                    User testUser = User.builder().roles(List.of(Role.builder().name(RoleEnum.FIND).id(1).build(), Role.builder().name(RoleEnum.SUPER_ADMIN).id(4).build(), Role.builder().name(RoleEnum.ADMIN).id(3).build(), Role.builder().name(RoleEnum.APPLICANT).id(2).build())).loginJourneyState(LoginJourneyState.USER_READY).build();
+                    User testUser = User.builder().roles(List.of(Role.builder().name(RoleEnum.FIND).id(1).build(),
+                            Role.builder().name(RoleEnum.SUPER_ADMIN).id(4).build(),
+                            Role.builder().name(RoleEnum.ADMIN).id(3).build(),
+                            Role.builder().name(RoleEnum.APPLICANT).id(2).build()))
+                            .loginJourneyState(LoginJourneyState.USER_READY).build();
                     when(userRepository.findBySub(any())).thenReturn(Optional.of(testUser));
                     when(oneLoginUserService.getUserBySub(any())).thenReturn(testUser);
 
@@ -203,8 +212,13 @@ public class CustomJwtServiceImplTest {
                     staticJwt.when(() -> decode(any())).thenCallRealMethod();
                     when(spiedVerification.build()).thenReturn(mockedJwtVerifier);
                     staticAlgorithm.when(() -> RSA256(any(), any())).thenReturn(mockAlgorithm);
-                    User testUser = User.builder().roles(List.of(Role.builder().name(RoleEnum.FIND).id(1).build(), Role.builder().name(RoleEnum.SUPER_ADMIN).id(4).build(), Role.builder().name(RoleEnum.ADMIN).id(3).build(), Role.builder().name(RoleEnum.APPLICANT).id(2).build())).loginJourneyState(LoginJourneyState.USER_READY).build();
-                    when(userRepository.findBySub(any())).thenReturn(Optional.of(User.builder().loginJourneyState(LoginJourneyState.USER_READY).build()));
+                    User testUser = User.builder().roles(List.of(Role.builder().name(RoleEnum.FIND).id(1).build(),
+                            Role.builder().name(RoleEnum.SUPER_ADMIN).id(4).build(),
+                            Role.builder().name(RoleEnum.ADMIN).id(3).build(),
+                            Role.builder().name(RoleEnum.APPLICANT).id(2).build()))
+                            .loginJourneyState(LoginJourneyState.USER_READY).build();
+                    when(userRepository.findBySub(any())).thenReturn(Optional.of(
+                            User.builder().loginJourneyState(LoginJourneyState.USER_READY).build()));
                     when(userRepository.findBySub(any())).thenReturn(Optional.of(testUser));
                     when(oneLoginUserService.getUserBySub(any())).thenReturn(testUser);
                     serviceUnderTest.isTokenValid(jwt);
@@ -322,7 +336,8 @@ public class CustomJwtServiceImplTest {
             when(oneLoginUserService.getUserBySub(any())).thenReturn(testUser);
             JwtPayload payload = new JwtPayload();
             payload.setRoles("[FIND, APPLY]");
-            doThrow(UnauthorizedException.class).when(oneLoginUserService).validateRoles(testUser.getRoles(),"[FIND, APPLY]");
+            doThrow(UnauthorizedException.class).when(oneLoginUserService)
+                    .validateRoles(testUser.getRoles(),"[FIND, APPLY]");
 
             assertThrows(UnauthorizedException.class, () -> serviceUnderTest.validateRolesInThePayload(payload));
         }

--- a/src/test/java/gov/cabinetofice/gapuserservice/service/jwt/CustomJwtServiceImplTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/service/jwt/CustomJwtServiceImplTest.java
@@ -285,7 +285,6 @@ public class CustomJwtServiceImplTest {
         payload.setRoles("[FIND, APPLY]");
         doThrow(UnauthorizedException.class).when(oneLoginUserService).validateRoles(testUser.getRoles(),"[FIND, APPLY]");
 
-        JwtPayload response = serviceUnderTest.validateRolesInThePayload(payload);
         assertThrows(UnauthorizedException.class, () -> serviceUnderTest.validateRolesInThePayload(payload));
     }
 

--- a/src/test/java/gov/cabinetofice/gapuserservice/service/jwt/CustomJwtServiceImplTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/service/jwt/CustomJwtServiceImplTest.java
@@ -82,6 +82,7 @@ public class CustomJwtServiceImplTest {
         serviceUnderTest = spy(new CustomJwtServiceImpl(
                 oneLoginUserService, jwtProperties, jwtBlacklistRepository, userRepository, clock));
         ReflectionTestUtils.setField(serviceUnderTest, "userServiceCookieName", "userServiceCookieName");
+        ReflectionTestUtils.setField(serviceUnderTest, "validateUserRolesInMiddleware", true);
     }
 
     @AfterEach

--- a/src/test/java/gov/cabinetofice/gapuserservice/service/jwt/CustomJwtServiceImplTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/service/jwt/CustomJwtServiceImplTest.java
@@ -8,7 +8,6 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.Verification;
 import com.nimbusds.jose.JOSEException;
 import gov.cabinetofice.gapuserservice.config.JwtProperties;
-import gov.cabinetofice.gapuserservice.dto.RoleDto;
 import gov.cabinetofice.gapuserservice.enums.LoginJourneyState;
 import gov.cabinetofice.gapuserservice.mappers.RoleMapper;
 import gov.cabinetofice.gapuserservice.model.Role;
@@ -103,7 +102,6 @@ public class CustomJwtServiceImplTest {
                     User testUser = User.builder().roles(List.of(Role.builder().name(RoleEnum.FIND).id(1).build(), Role.builder().name(RoleEnum.SUPER_ADMIN).id(4).build(), Role.builder().name(RoleEnum.ADMIN).id(3).build(), Role.builder().name(RoleEnum.APPLICANT).id(2).build())).loginJourneyState(LoginJourneyState.USER_READY).build();
                     when(userRepository.findBySub(any())).thenReturn(Optional.of(testUser));
                     when(oneLoginUserService.getUserBySub(any())).thenReturn(testUser);
-                    when(roleMapper.roleToRoleDto(any())).thenReturn(RoleDto.builder().name("FIND").build());
                     final boolean response = serviceUnderTest.isTokenValid(jwt);
                     assertThat(response).isTrue();
                     verify(mockedJwtVerifier, times(1)).verify(jwt);
@@ -147,7 +145,6 @@ public class CustomJwtServiceImplTest {
                     User testUser = User.builder().roles(List.of(Role.builder().name(RoleEnum.FIND).id(1).build(), Role.builder().name(RoleEnum.SUPER_ADMIN).id(4).build(), Role.builder().name(RoleEnum.ADMIN).id(3).build(), Role.builder().name(RoleEnum.APPLICANT).id(2).build())).loginJourneyState(LoginJourneyState.USER_READY).build();
                     when(userRepository.findBySub(any())).thenReturn(Optional.of(testUser));
                     when(oneLoginUserService.getUserBySub(any())).thenReturn(testUser);
-                    when(roleMapper.roleToRoleDto(any())).thenReturn(RoleDto.builder().name("FIND").build());
 
                     final boolean response = serviceUnderTest.isTokenValid(jwt);
 
@@ -174,7 +171,6 @@ public class CustomJwtServiceImplTest {
                     when(userRepository.findBySub(any())).thenReturn(Optional.of(User.builder().loginJourneyState(LoginJourneyState.USER_READY).build()));
                     when(userRepository.findBySub(any())).thenReturn(Optional.of(testUser));
                     when(oneLoginUserService.getUserBySub(any())).thenReturn(testUser);
-                    when(roleMapper.roleToRoleDto(any())).thenReturn(RoleDto.builder().name("FIND").build());
                     serviceUnderTest.isTokenValid(jwt);
                     staticAlgorithm.verify(() -> RSA256(any(), any()), times(1));
                     staticJwt.verify(() -> JWT.require(mockAlgorithm), times(1));

--- a/src/test/java/gov/cabinetofice/gapuserservice/service/jwt/CustomJwtServiceImplTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/service/jwt/CustomJwtServiceImplTest.java
@@ -9,7 +9,6 @@ import com.auth0.jwt.interfaces.Verification;
 import com.nimbusds.jose.JOSEException;
 import gov.cabinetofice.gapuserservice.config.JwtProperties;
 import gov.cabinetofice.gapuserservice.enums.LoginJourneyState;
-import gov.cabinetofice.gapuserservice.mappers.RoleMapper;
 import gov.cabinetofice.gapuserservice.model.Role;
 import gov.cabinetofice.gapuserservice.model.RoleEnum;
 import gov.cabinetofice.gapuserservice.model.User;
@@ -51,9 +50,6 @@ public class CustomJwtServiceImplTest {
     private JwtBlacklistRepository jwtBlacklistRepository;
 
     @Mock
-    private RoleMapper roleMapper;
-
-    @Mock
     private OneLoginUserService oneLoginUserService;
 
     @Mock
@@ -74,7 +70,7 @@ public class CustomJwtServiceImplTest {
                 .expiresAfter(60)
                 .build();
 
-        serviceUnderTest = spy(new CustomJwtServiceImpl(roleMapper, oneLoginUserService, jwtProperties, jwtBlacklistRepository, userRepository, clock));
+        serviceUnderTest = spy(new CustomJwtServiceImpl(oneLoginUserService, jwtProperties, jwtBlacklistRepository, userRepository, clock));
     }
 
     @Nested

--- a/src/test/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserServiceTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserServiceTest.java
@@ -444,7 +444,15 @@ public class OneLoginUserServiceTest {
     }
 
     @Test
-    void testvalidateAdminSessionThrowsInvalidExceptionWithEmptyUser() {
+    void testValidateRolesWhenUserHasNoRoles() {
+        String testPayloadRoles = "[FIND, APPLICANT]";
+        List<Role> testUserRoles = List.of();
+
+        assertThrows(UnauthorizedException.class, () -> oneLoginUserService.validateRoles(testUserRoles, testPayloadRoles));
+    }
+
+    @Test
+    void testValidateAdminSessionThrowsInvalidExceptionWithEmptyUser() {
         String  email = "email";
         String roles = "APPLICANT";
         when(userRepository.findByEmailAddress(email)).thenReturn(Optional.empty());

--- a/src/test/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserServiceTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserServiceTest.java
@@ -90,15 +90,14 @@ public class OneLoginUserServiceTest {
     }
 
     @Test
-    void shouldReturnUserWhenValidOneLoginSubIsGiven() {
+    void shouldReturnUserWhenValidSubIsGiven() {
+            User mockedUser = User.builder().gapUserId(1).build();
+            when(userRepository.findBySub("1234")).thenReturn(Optional.of(mockedUser));
+            User result = oneLoginUserService.getUserByUserSub("1234");
 
-        User mockedUser = User.builder().gapUserId(1).build();
-        when(userRepository.findBySub("1234")).thenReturn(Optional.of(mockedUser));
-        User result = oneLoginUserService.getUserByUserSub("1234");
-
-        assertThat(result).isNotNull();
-        assertThat(result).isEqualTo(mockedUser);
-        verify(userRepository, times(1)).findBySub("1234");
+            assertThat(result).isNotNull();
+            assertThat(result).isEqualTo(mockedUser);
+            verify(userRepository, times(1)).findBySub("1234");
     }
 
     @Test
@@ -145,6 +144,12 @@ public class OneLoginUserServiceTest {
     void shouldThrowUserNotFoundExceptionWhenInValidIdIsGiven() {
         when(userRepository.findById(anyInt())).thenReturn(Optional.empty());
         assertThrows(UserNotFoundException.class, () -> oneLoginUserService.getUserById(100));
+    }
+
+    @Test
+    void shouldThrowUserNotFoundExceptionWhenInValidSubIsGiven() {
+        when(userRepository.findBySub(anyString())).thenReturn(Optional.empty());
+        assertThrows(UserNotFoundException.class, () -> oneLoginUserService.getUserBySub("100"));
     }
 
     @Nested
@@ -452,7 +457,7 @@ public class OneLoginUserServiceTest {
     }
 
     @Test
-    void testValidateAdminSessionThrowsInvalidExceptionWithEmptyUser() {
+    void testValidateSessionsRolesThrowsInvalidExceptionWithEmptyUser() {
         String  email = "email";
         String roles = "APPLICANT";
         when(userRepository.findByEmailAddress(email)).thenReturn(Optional.empty());

--- a/src/test/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserServiceTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserServiceTest.java
@@ -448,7 +448,7 @@ public class OneLoginUserServiceTest {
         String  email = "email";
         String roles = "APPLICANT";
         when(userRepository.findByEmailAddress(email)).thenReturn(Optional.empty());
-        assertThrows(InvalidRequestException.class, () -> oneLoginUserService.validateAdminSession(email, roles));
+        assertThrows(InvalidRequestException.class, () -> oneLoginUserService.validateSessionsRoles(email, roles));
     }
 
     @Test

--- a/src/test/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserServiceTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/service/user/OneLoginUserServiceTest.java
@@ -1,8 +1,11 @@
 package gov.cabinetofice.gapuserservice.service.user;
 
+import gov.cabinetofice.gapuserservice.dto.RoleDto;
 import gov.cabinetofice.gapuserservice.dto.UserQueryDto;
 import gov.cabinetofice.gapuserservice.exceptions.DepartmentNotFoundException;
+import gov.cabinetofice.gapuserservice.exceptions.UnauthorizedException;
 import gov.cabinetofice.gapuserservice.exceptions.UserNotFoundException;
+import gov.cabinetofice.gapuserservice.mappers.RoleMapper;
 import gov.cabinetofice.gapuserservice.model.Department;
 import gov.cabinetofice.gapuserservice.model.Role;
 import gov.cabinetofice.gapuserservice.model.RoleEnum;
@@ -25,8 +28,7 @@ import org.springframework.data.domain.Pageable;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
 
@@ -41,6 +43,9 @@ public class OneLoginUserServiceTest {
 
     @Mock
     private DepartmentRepository departmentRepository;
+
+    @Mock
+    private RoleMapper roleMapper;
 
     @Mock
     private RoleRepository roleRepository;
@@ -399,5 +404,30 @@ public class OneLoginUserServiceTest {
         assertThat(updatedUser.getRoles().size()).isEqualTo(4);
         assertThat(updatedUser.getRoles().stream().anyMatch(role -> role.getName().equals(RoleEnum.APPLICANT))).isTrue();
         assertThat(updatedUser.getRoles().stream().anyMatch(role -> role.getName().equals(RoleEnum.FIND))).isTrue();
-    }}
+    }
+
+    @Test
+    void testValidateRolesWhenRolesMatch() {
+        Role find = Role.builder().name(RoleEnum.FIND).id(1).build();
+        Role applicant = Role.builder().name(RoleEnum.APPLICANT).id(2).build();
+        String testPayloadRoles = "[FIND, APPLICANT]";
+        List<Role> testUserRoles = List.of(find,applicant);
+        when(roleMapper.roleToRoleDto(find)).thenReturn(RoleDto.builder().name("FIND").build());
+        when(roleMapper.roleToRoleDto(applicant)).thenReturn(RoleDto.builder().name("APPLICANT").build());
+
+        assertDoesNotThrow(() -> oneLoginUserService.validateRoles(testUserRoles, testPayloadRoles));
+    }
+
+    @Test
+    void testValidateRolesWhenRolesDoNotMatch() {
+        Role find = Role.builder().name(RoleEnum.FIND).id(1).build();
+        Role applicant = Role.builder().name(RoleEnum.APPLICANT).id(2).build();
+        String testPayloadRoles = "[FIND, APPLICANT, ADMIN]";
+        List<Role> testUserRoles = List.of(find,applicant);
+        when(roleMapper.roleToRoleDto(find)).thenReturn(RoleDto.builder().name("FIND").build());
+        when(roleMapper.roleToRoleDto(applicant)).thenReturn(RoleDto.builder().name("APPLICANT").build());
+
+        assertThrows(UnauthorizedException.class, () -> oneLoginUserService.validateRoles(testUserRoles, testPayloadRoles));
+    }
+}
 

--- a/src/test/java/gov/cabinetofice/gapuserservice/util/HelperUtilsTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/util/HelperUtilsTest.java
@@ -1,0 +1,20 @@
+package gov.cabinetofice.gapuserservice.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+
+@ExtendWith(MockitoExtension.class)
+public class HelperUtilsTest {
+    @Test
+    void shouldRemoveSquareBracketsAndTrimAndReturnASet() {
+        List<String> input = List.of("[FIND ", "APPLY", "ADMIN] ");
+        Set<String> output = Set.of("FIND", "APPLY", "ADMIN");
+        Set<String> result = HelperUtils.removeSquareBracketsAndTrim(input);
+        assert(result.equals(output));
+    }
+
+}

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
@@ -7,8 +7,8 @@ import gov.cabinetofice.gapuserservice.dto.OneLoginUserInfoDto;
 import gov.cabinetofice.gapuserservice.dto.PrivacyPolicyDto;
 import gov.cabinetofice.gapuserservice.dto.StateCookieDto;
 import gov.cabinetofice.gapuserservice.enums.LoginJourneyState;
-import gov.cabinetofice.gapuserservice.exceptions.UnauthorizedException;
 import gov.cabinetofice.gapuserservice.exceptions.UnauthorizedClientException;
+import gov.cabinetofice.gapuserservice.exceptions.UnauthorizedException;
 import gov.cabinetofice.gapuserservice.model.Nonce;
 import gov.cabinetofice.gapuserservice.model.Role;
 import gov.cabinetofice.gapuserservice.model.RoleEnum;
@@ -25,26 +25,28 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 import org.springframework.web.util.WebUtils;
-import org.json.JSONObject;
 
 import java.util.*;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -79,6 +81,7 @@ class LoginControllerV2Test {
 
     @Mock
     private NonceRepository nonceRepository;
+
 
     @Mock
     private LoggingUtils loggingUtils;
@@ -757,18 +760,14 @@ class LoginControllerV2Test {
     void testValidateAdminSession() {
         String emailAddress = "test@email.com";
         String roles = "[FIND, APPLY]";
-        OneLoginUserService oneLoginUserServiceMock = mock(OneLoginUserService.class);
-        doNothing().when(oneLoginUserServiceMock).validateAdminSession(emailAddress, roles);
-
-        assertDoesNotThrow(() -> oneLoginUserServiceMock.validateAdminSession(emailAddress, roles));
+        ResponseEntity<Boolean> response = loginController.validateSessionsRoles(emailAddress, roles);
+        assertThat(response).isEqualTo(ResponseEntity.ok(Boolean.TRUE));
     }
     @Test
     void testValidateAdminSessionWithInvalidSession() {
         String emailAddress = "test@email.com";
         String roles = "[FIND, APPLY]";
-        OneLoginUserService oneLoginUserServiceMock = mock(OneLoginUserService.class);
-        doThrow(UnauthorizedException.class).when(oneLoginUserServiceMock).validateAdminSession(emailAddress, roles);
-
-        assertThrows(UnauthorizedException.class, () -> oneLoginUserServiceMock.validateAdminSession(emailAddress, roles));
+        doThrow(UnauthorizedException.class).when(oneLoginUserService).validateSessionsRoles(emailAddress, roles);
+        assertThrows(UnauthorizedException.class, () -> loginController.validateSessionsRoles(emailAddress, roles));
     }
 }

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
@@ -7,6 +7,7 @@ import gov.cabinetofice.gapuserservice.dto.OneLoginUserInfoDto;
 import gov.cabinetofice.gapuserservice.dto.PrivacyPolicyDto;
 import gov.cabinetofice.gapuserservice.dto.StateCookieDto;
 import gov.cabinetofice.gapuserservice.enums.LoginJourneyState;
+import gov.cabinetofice.gapuserservice.exceptions.UnauthorizedException;
 import gov.cabinetofice.gapuserservice.model.Nonce;
 import gov.cabinetofice.gapuserservice.model.Role;
 import gov.cabinetofice.gapuserservice.model.RoleEnum;
@@ -41,6 +42,7 @@ import org.json.JSONObject;
 import java.util.*;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -738,5 +740,24 @@ class LoginControllerV2Test {
                 Assertions.assertEquals(applicantBaseUrl, methodResponse.getUrl());
             }
         }
+    }
+
+    @Test
+    void testValidateAdminSession() {
+        String emailAddress = "test@email.com";
+        String roles = "[FIND, APPLY]";
+        OneLoginUserService oneLoginUserServiceMock = mock(OneLoginUserService.class);
+        doNothing().when(oneLoginUserServiceMock).validateAdminSession(emailAddress, roles);
+
+        assertDoesNotThrow(() -> oneLoginUserServiceMock.validateAdminSession(emailAddress, roles));
+    }
+    @Test
+    void testValidateAdminSessionWithInvalidSession() {
+        String emailAddress = "test@email.com";
+        String roles = "[FIND, APPLY]";
+        OneLoginUserService oneLoginUserServiceMock = mock(OneLoginUserService.class);
+        doThrow(UnauthorizedException.class).when(oneLoginUserServiceMock).validateAdminSession(emailAddress, roles);
+
+        assertThrows(UnauthorizedException.class, () -> oneLoginUserServiceMock.validateAdminSession(emailAddress, roles));
     }
 }

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
@@ -13,6 +13,7 @@ import gov.cabinetofice.gapuserservice.model.RoleEnum;
 import gov.cabinetofice.gapuserservice.model.User;
 import gov.cabinetofice.gapuserservice.repository.NonceRepository;
 import gov.cabinetofice.gapuserservice.service.OneLoginService;
+import gov.cabinetofice.gapuserservice.service.RoleService;
 import gov.cabinetofice.gapuserservice.service.encryption.Sha512Service;
 import gov.cabinetofice.gapuserservice.service.jwt.impl.CustomJwtServiceImpl;
 import gov.cabinetofice.gapuserservice.util.WebUtil;
@@ -64,6 +65,9 @@ class LoginControllerV2Test {
     private CustomJwtServiceImpl customJwtService;
 
     @Mock
+    private RoleService roleService;
+
+    @Mock
     private Sha512Service encryptionService;
 
     @Mock
@@ -79,7 +83,7 @@ class LoginControllerV2Test {
                 .defaultRedirectUrl("https://www.find-government-grants.service.gov.uk/")
                 .build();
 
-        loginController = new LoginControllerV2(oneLoginService, customJwtService, configProperties, encryptionService, nonceRepository, findProperties);
+        loginController = new LoginControllerV2(oneLoginService, roleService, customJwtService, configProperties, encryptionService, nonceRepository, findProperties);
         ReflectionTestUtils.setField(loginController, "userServiceCookieName", "userServiceCookieName");
         ReflectionTestUtils.setField(loginController, "adminBaseUrl", "/adminBaseUrl");
         ReflectionTestUtils.setField(loginController, "applicantBaseUrl", "/applicantBaseUrl");

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
@@ -757,14 +757,14 @@ class LoginControllerV2Test {
     }
 
     @Test
-    void testValidateAdminSession() {
+    void testValidateSessionsRoles() {
         String emailAddress = "test@email.com";
         String roles = "[FIND, APPLY]";
         ResponseEntity<Boolean> response = loginController.validateSessionsRoles(emailAddress, roles);
         assertThat(response).isEqualTo(ResponseEntity.ok(Boolean.TRUE));
     }
     @Test
-    void testValidateAdminSessionWithInvalidSession() {
+    void testValidateSessionsRolesWithInvalidSession() {
         String emailAddress = "test@email.com";
         String roles = "[FIND, APPLY]";
         doThrow(UnauthorizedException.class).when(oneLoginUserService).validateSessionsRoles(emailAddress, roles);

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/LoginControllerV2Test.java
@@ -16,6 +16,7 @@ import gov.cabinetofice.gapuserservice.service.OneLoginService;
 import gov.cabinetofice.gapuserservice.service.RoleService;
 import gov.cabinetofice.gapuserservice.service.encryption.Sha512Service;
 import gov.cabinetofice.gapuserservice.service.jwt.impl.CustomJwtServiceImpl;
+import gov.cabinetofice.gapuserservice.service.user.OneLoginUserService;
 import gov.cabinetofice.gapuserservice.util.WebUtil;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -71,6 +72,9 @@ class LoginControllerV2Test {
     private Sha512Service encryptionService;
 
     @Mock
+    private OneLoginUserService oneLoginUserService;
+
+    @Mock
     private NonceRepository nonceRepository;
 
     private static MockedStatic<WebUtils> mockedWebUtils;
@@ -83,7 +87,7 @@ class LoginControllerV2Test {
                 .defaultRedirectUrl("https://www.find-government-grants.service.gov.uk/")
                 .build();
 
-        loginController = new LoginControllerV2(oneLoginService, roleService, customJwtService, configProperties, encryptionService, nonceRepository, findProperties);
+        loginController = new LoginControllerV2(oneLoginService, roleService, customJwtService, configProperties, encryptionService, nonceRepository, oneLoginUserService, findProperties);
         ReflectionTestUtils.setField(loginController, "userServiceCookieName", "userServiceCookieName");
         ReflectionTestUtils.setField(loginController, "adminBaseUrl", "/adminBaseUrl");
         ReflectionTestUtils.setField(loginController, "applicantBaseUrl", "/applicantBaseUrl");

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/UserControllerTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/UserControllerTest.java
@@ -8,6 +8,7 @@ import gov.cabinetofice.gapuserservice.model.RoleEnum;
 import gov.cabinetofice.gapuserservice.model.User;
 import gov.cabinetofice.gapuserservice.service.DepartmentService;
 import gov.cabinetofice.gapuserservice.service.RoleService;
+import gov.cabinetofice.gapuserservice.service.jwt.impl.CustomJwtServiceImpl;
 import gov.cabinetofice.gapuserservice.service.user.OneLoginUserService;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,9 @@ class UserControllerTest {
 
     @Mock
     private DepartmentService departmentService;
+    
+    @Mock
+    private CustomJwtServiceImpl customJwtService;
 
     @Mock
     private RoleService roleService;
@@ -83,6 +87,7 @@ class UserControllerTest {
     void shouldDeleteUserWhenValidIdIsGiven() {
         final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
         when(roleService.isSuperAdmin(httpRequest)).thenReturn(true);
+        when(customJwtService.getUserFromJwt(httpRequest)).thenReturn(User.builder().build());
         final ResponseEntity<String> methodResponse = controller.deleteUser(httpRequest, 1);
 
         assertThat(methodResponse).isEqualTo(ResponseEntity.ok("success"));

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/UserControllerTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/UserControllerTest.java
@@ -65,6 +65,15 @@ class UserControllerTest {
     }
 
     @Test
+    void testSuperAdminThrowsInvalidRequestWithNoUser() {
+        final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
+        when(roleService.isSuperAdmin(httpRequest)).thenReturn(true);
+        when(customJwtService.getUserFromJwt(httpRequest)).thenReturn(Optional.empty());
+
+        assertThrows(InvalidRequestException.class, () -> controller.updateRoles(httpRequest, List.of(), 1));
+    }
+
+    @Test
     void shouldReturnUserWhenValidIdIsGiven() {
         final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
         User mockUser = User.builder().sub("1").gapUserId(1)
@@ -117,6 +126,16 @@ class UserControllerTest {
 
         assertThrows(UnsupportedOperationException.class, () -> controller.deleteUser(httpRequest, 1));
     }
+
+    @Test
+    void shouldThrowErrorWhenUserIsEmpty() {
+        final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
+        when(roleService.isSuperAdmin(httpRequest)).thenReturn(true);
+        when(customJwtService.getUserFromJwt(httpRequest)).thenReturn(Optional.empty());
+
+        assertThrows(InvalidRequestException.class, () -> controller.deleteUser(httpRequest, 1));
+    }
+
 
     @Test
     public void testGetUserFromJwt() throws Exception {

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/UserControllerTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/UserControllerTest.java
@@ -138,7 +138,7 @@ class UserControllerTest {
 
 
     @Test
-    public void testGetUserFromJwt() throws Exception {
+    public void testGetUserFromJwt() {
         User mockUser = User.builder().gapUserId(1).build();
         when(roleService.isSuperAdmin(any(HttpServletRequest.class)))
                 .thenReturn(true);
@@ -150,13 +150,13 @@ class UserControllerTest {
     }
 
     @Test
-    public void testGetUserFromJwtThrowsErrorWhenNotSuperAdmin() throws Exception {
+    public void testGetUserFromJwtThrowsErrorWhenNotSuperAdmin() {
         Mockito.doThrow(ForbiddenException.class).when(roleService).isSuperAdmin(any(HttpServletRequest.class));
         assertThrows(ForbiddenException.class, () -> controller.getUserFromJwt(mock(HttpServletRequest.class)));
     }
 
     @Test
-    public void testGetUserFromJwtThrowsInvalidRequestWhenUserIsEmpty() throws Exception {
+    public void testGetUserFromJwtThrowsInvalidRequestWhenUserIsEmpty()  {
         when(roleService.isSuperAdmin(any(HttpServletRequest.class)))
                 .thenReturn(true);
         when(customJwtService.getUserFromJwt(any(HttpServletRequest.class)))

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/UserControllerTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/UserControllerTest.java
@@ -49,10 +49,21 @@ class UserControllerTest {
     void updateRolesForUserId() {
         final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
         when(roleService.isSuperAdmin(httpRequest)).thenReturn(true);
+        when(customJwtService.getUserFromJwt(httpRequest)).thenReturn(Optional.of(User.builder().gapUserId(2).build()));
         final ResponseEntity<String> methodResponse = controller.updateRoles(httpRequest, List.of(1,2), 1);
 
         assertThat(methodResponse).isEqualTo(ResponseEntity.ok("success"));
     }
+
+    @Test
+    void testSuperAdminCannotBlockThemselves() {
+        final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
+        when(roleService.isSuperAdmin(httpRequest)).thenReturn(true);
+        when(customJwtService.getUserFromJwt(httpRequest)).thenReturn(Optional.of(User.builder().gapUserId(1).build()));
+
+        assertThrows(UnsupportedOperationException.class, () -> controller.updateRoles(httpRequest, List.of(), 1));
+    }
+
     @Test
     void shouldReturnUserWhenValidIdIsGiven() {
         final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
@@ -92,10 +103,19 @@ class UserControllerTest {
     void shouldDeleteUserWhenValidIdIsGiven() {
         final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
         when(roleService.isSuperAdmin(httpRequest)).thenReturn(true);
-        when(customJwtService.getUserFromJwt(httpRequest)).thenReturn(Optional.of(User.builder().build()));
+        when(customJwtService.getUserFromJwt(httpRequest)).thenReturn(Optional.of(User.builder().gapUserId(2).build()));
         final ResponseEntity<String> methodResponse = controller.deleteUser(httpRequest, 1);
 
         assertThat(methodResponse).isEqualTo(ResponseEntity.ok("success"));
+    }
+
+    @Test
+    void shouldThrowErrorWhenAdminTriesToDeleteThemselves() {
+        final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
+        when(roleService.isSuperAdmin(httpRequest)).thenReturn(true);
+        when(customJwtService.getUserFromJwt(httpRequest)).thenReturn(Optional.of(User.builder().gapUserId(1).build()));
+
+        assertThrows(UnsupportedOperationException.class, () -> controller.deleteUser(httpRequest, 1));
     }
 
     @Test

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/UserControllerTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/UserControllerTest.java
@@ -135,6 +135,15 @@ class UserControllerTest {
         Mockito.doThrow(ForbiddenException.class).when(roleService).isSuperAdmin(any(HttpServletRequest.class));
         assertThrows(ForbiddenException.class, () -> controller.getUserFromJwt(mock(HttpServletRequest.class)));
     }
+
+    @Test
+    public void testGetUserFromJwtThrowsInvalidRequestWhenUserIsEmpty() throws Exception {
+        when(roleService.isSuperAdmin(any(HttpServletRequest.class)))
+                .thenReturn(true);
+        when(customJwtService.getUserFromJwt(any(HttpServletRequest.class)))
+                .thenReturn(Optional.empty());
+        assertThrows(InvalidRequestException.class, () -> controller.getUserFromJwt(mock(HttpServletRequest.class)));
+    }
     
     @Test
     void updateDepartmentCantBeCalledOnApplicantAndFindUser() {

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/UserControllerTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/UserControllerTest.java
@@ -92,4 +92,17 @@ class UserControllerTest {
 
         assertThat(methodResponse).isEqualTo(ResponseEntity.ok("success"));
     }
+
+    @Test
+    public void testGetUserFromJwt() throws Exception {
+        User mockUser = User.builder().gapUserId(1).build();
+        when(roleService.isSuperAdmin(any(HttpServletRequest.class)))
+                .thenReturn(true);
+        when(customJwtService.getUserFromJwt(any(HttpServletRequest.class)))
+                .thenReturn(mockUser);
+        final ResponseEntity<UserDto> methodResponse = controller.getUserFromJwt(mock(HttpServletRequest.class));
+
+        assertThat(methodResponse.getBody()).isEqualTo(new UserDto(mockUser));
+
+    }
 }


### PR DESCRIPTION
## Description

Ticket # GAP-2060

- adds a endpoint to validate the admin session
- updates jwtService.verifyToken call to validate roles
- adds an endpoint to get the user data attached to the jwt (super-admin fe uses this to check who they are blocking / deleting)
- Stops super admins from blocking themselves

Related prs:

- https://github.com/cabinetoffice/gap-find-admin-backend/pull/29
- https://github.com/cabinetoffice/gap-find-apply-web/pull/68 
- https://eu-west-2.console.aws.amazon.com/codesuite/codecommit/repositories/GAP-infra/pull-requests/96/details?region=eu-west-2

Todos:
- add more unit tests


## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
