### PR TITLE
Adding roles_users index & replacing unique constraint with PK constraint

### DIFF
--- a/src/main/resources/db/migration/V1_19__users_roles_index.sql
+++ b/src/main/resources/db/migration/V1_19__users_roles_index.sql
@@ -1,3 +1,3 @@
 ALTER TABLE roles_users DROP CONSTRAINT unique_user_role;
-ALTER TABLE roles_users ADD CONSTRAINT roles_users_test_pkey PRIMARY KEY (roles_id, users_gap_user_id);
+ALTER TABLE roles_users ADD CONSTRAINT roles_users_pkey PRIMARY KEY (roles_id, users_gap_user_id);
 CREATE UNIQUE INDEX roles_users_index ON roles_users (roles_id, users_gap_user_id);

--- a/src/main/resources/db/migration/V1_19__users_roles_index.sql
+++ b/src/main/resources/db/migration/V1_19__users_roles_index.sql
@@ -1,0 +1,3 @@
+ALTER TABLE roles_users DROP CONSTRAINT unique_user_role;
+ALTER TABLE roles_users ADD CONSTRAINT roles_users_test_pkey PRIMARY KEY (roles_id, users_gap_user_id);
+CREATE UNIQUE INDEX roles_users_index ON roles_users (roles_id, users_gap_user_id);


### PR DESCRIPTION
roles_users table changing from:
```
CREATE TABLE IF NOT EXISTS public.roles_users
(
    roles_id integer NOT NULL,
    users_gap_user_id integer NOT NULL,
    CONSTRAINT unique_user_role UNIQUE (roles_id, users_gap_user_id),
    CONSTRAINT fk2mck5s7km22t2on8h2jpn44xq FOREIGN KEY (roles_id)
        REFERENCES public.roles (id) MATCH SIMPLE
        ON UPDATE NO ACTION
        ON DELETE CASCADE,
    CONSTRAINT fkhu2gdj9we2ucvgwy1qdfm5a5s FOREIGN KEY (users_gap_user_id)
        REFERENCES public.gap_users (gap_user_id) MATCH SIMPLE
        ON UPDATE NO ACTION
        ON DELETE CASCADE
)
```

to:
```
CREATE TABLE IF NOT EXISTS public.roles_users
(
    roles_id integer NOT NULL,
    users_gap_user_id integer NOT NULL,
    CONSTRAINT roles_users_pkey PRIMARY KEY (roles_id, users_gap_user_id),
    CONSTRAINT fk2mck5s7km22t2on8h2jpn44xq FOREIGN KEY (roles_id)
        REFERENCES public.roles (id) MATCH SIMPLE
        ON UPDATE NO ACTION
        ON DELETE CASCADE,
    CONSTRAINT fkhu2gdj9we2ucvgwy1qdfm5a5s FOREIGN KEY (users_gap_user_id)
        REFERENCES public.gap_users (gap_user_id) MATCH SIMPLE
        ON UPDATE NO ACTION
        ON DELETE CASCADE
)

CREATE UNIQUE INDEX IF NOT EXISTS roles_users_index
    ON public.roles_users USING btree
    (roles_id ASC NULLS LAST, users_gap_user_id ASC NULLS LAST)
    TABLESPACE pg_default;
```