### PR TITLE
Removing unneccessary aws-sdk import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,9 +201,10 @@
 		</dependency>
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
-			<artifactId>aws-sdk-java</artifactId>
-			<version>2.21.0</version>
+			<artifactId>regions</artifactId>
+			<version>2.21.10</version>
 		</dependency>
+
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-encryption-sdk-java</artifactId>


### PR DESCRIPTION
Reduces docker image size from 600mb to 80mb, speeds up CD significantly