### PR TITLE
TMI2-445: Fix AWS Secret Manager credentials

### DIFF
--- a/src/main/java/gov/cabinetofice/gapuserservice/config/BeanConfig.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/config/BeanConfig.java
@@ -70,7 +70,6 @@ public class BeanConfig {
     public static SecretsManagerClient getSecretsManagerClient() {
         return SecretsManagerClient.builder()
                 .region(Region.EU_WEST_2)
-                .credentialsProvider(ProfileCredentialsProvider.create())
                 .build();
     }
 

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/SpotlightService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/SpotlightService.java
@@ -78,6 +78,10 @@ public class SpotlightService {
     }
 
     public void exchangeAuthorizationToken(String authorizationCode, String state) throws IOException {
+        log.debug("SpotlightService exchangeAuthorizationToken");
+        log.debug("authorizationCode: {}", authorizationCode);
+        log.debug("state: {}", state);
+
         String grantType = "authorization_code";
 
         if (!state.equals(this.state)) {
@@ -92,10 +96,6 @@ public class SpotlightService {
                 .build()
                 .toUriString();
 
-        log.debug("SpotlightController callback");
-        log.debug("authorizationCode: {}", authorizationCode);
-        log.debug("state: {}", state);
-
         final String requestBody = "code=" + authorizationCode +
                 "&client_id=" + spotlightConfig.getClientId() +
                 "&client_secret=" + spotlightConfig.getClientSecret() +
@@ -108,6 +108,8 @@ public class SpotlightService {
         try {
             responseJSON = RestUtils.postRequestWithBody(tokenEndpoint, requestBody,
                     "application/x-www-form-urlencoded");
+            log.debug("responseJSON: {}", responseJSON);
+
             String accessToken = responseJSON
                     .get("access_token")
                     .toString();


### PR DESCRIPTION
## Description

https://technologyprogramme.atlassian.net/browse/TMI2-445

Remove the profilecredentials from SecretManager and use the normal AWS credential flow

## Type of change

Please check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [X] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
