### PR TITLE
TMI2-556: Fix spotlight oauth query 

### DIFF
--- a/src/main/java/gov/cabinetofice/gapuserservice/repository/SpotlightOAuthAuditRepository.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/repository/SpotlightOAuthAuditRepository.java
@@ -1,5 +1,6 @@
 package gov.cabinetofice.gapuserservice.repository;
 
+import gov.cabinetofice.gapuserservice.enums.SpotlightOAuthAuditStatus;
 import gov.cabinetofice.gapuserservice.model.SpotlightOAuthAudit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -7,4 +8,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface SpotlightOAuthAuditRepository extends JpaRepository<SpotlightOAuthAudit, Integer> {
     SpotlightOAuthAudit findFirstByOrderByIdDesc();
+
+    SpotlightOAuthAudit findFirstByStatusOrStatusOrderByIdDesc(SpotlightOAuthAuditStatus status, SpotlightOAuthAuditStatus status1);
+
 }

--- a/src/main/java/gov/cabinetofice/gapuserservice/repository/SpotlightOAuthAuditRepository.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/repository/SpotlightOAuthAuditRepository.java
@@ -5,9 +5,11 @@ import gov.cabinetofice.gapuserservice.model.SpotlightOAuthAudit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+
 @Repository
 public interface SpotlightOAuthAuditRepository extends JpaRepository<SpotlightOAuthAudit, Integer> {
 
-    SpotlightOAuthAudit findFirstByStatusOrStatusOrderByIdDesc(SpotlightOAuthAuditStatus status, SpotlightOAuthAuditStatus status1);
+    SpotlightOAuthAudit findFirstByStatusInOrderByIdDesc(Collection<SpotlightOAuthAuditStatus> statuses);
 
 }

--- a/src/main/java/gov/cabinetofice/gapuserservice/repository/SpotlightOAuthAuditRepository.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/repository/SpotlightOAuthAuditRepository.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SpotlightOAuthAuditRepository extends JpaRepository<SpotlightOAuthAudit, Integer> {
-    SpotlightOAuthAudit findFirstByOrderByIdDesc();
 
     SpotlightOAuthAudit findFirstByStatusOrStatusOrderByIdDesc(SpotlightOAuthAuditStatus status, SpotlightOAuthAuditStatus status1);
 

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/SpotlightService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/SpotlightService.java
@@ -3,6 +3,7 @@ package gov.cabinetofice.gapuserservice.service;
 import com.nimbusds.jose.shaded.gson.JsonObject;
 import com.nimbusds.jose.shaded.gson.JsonParser;
 import gov.cabinetofice.gapuserservice.config.SpotlightConfig;
+import gov.cabinetofice.gapuserservice.enums.SpotlightOAuthAuditStatus;
 import gov.cabinetofice.gapuserservice.exceptions.InvalidRequestException;
 import gov.cabinetofice.gapuserservice.exceptions.SpotlightInvalidStateException;
 import gov.cabinetofice.gapuserservice.model.SpotlightOAuthAudit;
@@ -47,8 +48,8 @@ public class SpotlightService {
     private final static String ACCESS_TOKEN_NAME = "access_token";
     private final static String REFRESH_TOKEN_NAME = "refresh_token";
 
-    public SpotlightOAuthAudit getLatestAudit() {
-        return spotlightOAuthAuditRepository.findFirstByOrderByIdDesc();
+    public SpotlightOAuthAudit getLatestSuccessOrFailureAudit() {
+        return spotlightOAuthAuditRepository.findFirstByStatusOrStatusOrderByIdDesc(SpotlightOAuthAuditStatus.SUCCESS, SpotlightOAuthAuditStatus.FAILURE);
     }
 
     public void saveAudit(SpotlightOAuthAudit spotlightOAuthAudit) {

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/SpotlightService.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/SpotlightService.java
@@ -27,6 +27,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Base64;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -49,7 +50,7 @@ public class SpotlightService {
     private final static String REFRESH_TOKEN_NAME = "refresh_token";
 
     public SpotlightOAuthAudit getLatestSuccessOrFailureAudit() {
-        return spotlightOAuthAuditRepository.findFirstByStatusOrStatusOrderByIdDesc(SpotlightOAuthAuditStatus.SUCCESS, SpotlightOAuthAuditStatus.FAILURE);
+        return spotlightOAuthAuditRepository.findFirstByStatusInOrderByIdDesc(List.of(SpotlightOAuthAuditStatus.SUCCESS, SpotlightOAuthAuditStatus.FAILURE));
     }
 
     public void saveAudit(SpotlightOAuthAudit spotlightOAuthAudit) {

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/SpotlightController.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/SpotlightController.java
@@ -48,7 +48,7 @@ public class SpotlightController {
             throw new ForbiddenException();
         }
         SpotlightOAuthAudit audit = spotlightService.getLatestSuccessOrFailureAudit();
-        if(Objects.equals(null, audit)) {
+        if (Objects.equals(null, audit)) {
             throw new InvalidRequestException("No audit found");
         }
         SpotlightIntegrationAuditDto spotlightIntegrationAuditDto = new SpotlightIntegrationAuditDto(

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/SpotlightController.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/SpotlightController.java
@@ -47,8 +47,8 @@ public class SpotlightController {
         if (!roleService.isSuperAdmin(httpRequest)) {
             throw new ForbiddenException();
         }
-        SpotlightOAuthAudit audit = spotlightService.getLatestAudit();
-        if (Objects.equals(null, audit)) {
+        SpotlightOAuthAudit audit = spotlightService.getLatestSuccessOrFailureAudit();
+        if(Objects.equals(null, audit)) {
             throw new InvalidRequestException("No audit found");
         }
         SpotlightIntegrationAuditDto spotlightIntegrationAuditDto = new SpotlightIntegrationAuditDto(

--- a/src/test/java/gov/cabinetofice/gapuserservice/service/SpotlightServiceTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/service/SpotlightServiceTest.java
@@ -1,11 +1,8 @@
 package gov.cabinetofice.gapuserservice.service;
 
 import gov.cabinetofice.gapuserservice.config.SpotlightConfig;
-import gov.cabinetofice.gapuserservice.enums.SpotlightOAuthAuditEvent;
-import gov.cabinetofice.gapuserservice.enums.SpotlightOAuthAuditStatus;
 import gov.cabinetofice.gapuserservice.exceptions.InvalidRequestException;
 import gov.cabinetofice.gapuserservice.exceptions.SpotlightInvalidStateException;
-import gov.cabinetofice.gapuserservice.model.SpotlightOAuthAudit;
 import gov.cabinetofice.gapuserservice.repository.SpotlightOAuthAuditRepository;
 import gov.cabinetofice.gapuserservice.util.RestUtils;
 import org.apache.http.impl.client.HttpClients;
@@ -134,16 +131,6 @@ class SpotlightServiceTest {
                 () -> spotlightService.exchangeAuthorizationToken("1234", "stateValueInvalid"));
 
     }
-
-    @Test
-    void shouldGetLatestAudit() {
-        SpotlightOAuthAudit spotlightOAuthAudit = SpotlightOAuthAudit.builder().id(1).status(
-                SpotlightOAuthAuditStatus.FAILURE).event(SpotlightOAuthAuditEvent.AUTHORISE).build();
-        when(spotlightOAuthAuditRepository.findFirstByOrderByIdDesc()).thenReturn(spotlightOAuthAudit);
-
-        assertEquals(spotlightOAuthAudit, spotlightService.getLatestAudit());
-    }
-
 
     @Test
     void shouldRefreshTokenTest() throws Exception {

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/SpotlightControllerTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/SpotlightControllerTest.java
@@ -172,7 +172,7 @@ public class SpotlightControllerTest {
     @Nested
     class IntegrationTest {
         @Test
-        void shouldReturnIntegrationAuditDto() throws Exception {
+        void shouldReturnIntegrationAuditDto() {
             HttpServletRequest httpRequest = mock(HttpServletRequest.class);
             Date date = new Date();
             SpotlightOAuthAudit audit = SpotlightOAuthAudit.builder().event(SpotlightOAuthAuditEvent.AUTHORISE)
@@ -181,7 +181,7 @@ public class SpotlightControllerTest {
                     SpotlightOAuthAuditEvent.AUTHORISE, SpotlightOAuthAuditStatus.FAILURE, date);
 
             when(roleService.isSuperAdmin(any(HttpServletRequest.class))).thenReturn(true);
-            when(spotlightService.getLatestAudit()).thenReturn(audit);
+            when(spotlightService.getLatestSuccessOrFailureAudit()).thenReturn(audit);
             assertEquals(SpotlightController.getIntegrations(httpRequest), ResponseEntity.ok(auditDto));
         }
 
@@ -189,9 +189,17 @@ public class SpotlightControllerTest {
         void shouldThrowInvalidRequestWhenNoIntegrationAuditFound() {
             HttpServletRequest httpRequest = mock(HttpServletRequest.class);
             when(roleService.isSuperAdmin(any(HttpServletRequest.class))).thenReturn(true);
-            when(spotlightService.getLatestAudit()).thenReturn(null);
+            when(spotlightService.getLatestSuccessOrFailureAudit()).thenReturn(null);
 
             assertThrows(InvalidRequestException.class, () -> SpotlightController.getIntegrations(httpRequest));
+        }
+
+        @Test
+        void shouldThrowForbiddenExceptionWhenUserIsNotSuperAdmin()  {
+            HttpServletRequest httpRequest = mock(HttpServletRequest.class);
+            when(roleService.isSuperAdmin(any(HttpServletRequest.class))).thenReturn(false);
+
+            assertThrows(ForbiddenException.class, () -> SpotlightController.getIntegrations(httpRequest));
         }
     }
 


### PR DESCRIPTION
## Description
The old query was just getting the latest audit including ones with the status if 'REQUEST'. Because of how this is handled in the frontend, it was causing the integrations page to say Spotlight was connected even when it was not. Therefore, the new query get the latest audit which has a status of either 'SUCCESS' or 'FAILURE' 

Ticket # and link
TMI2-556: https://technologyprogramme.atlassian.net/browse/TMI2-556

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
