### PR TITLE
GAP-2381 - Adding template class to root of all user service HTML pages

### DIFF
--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" class="govuk-template">
     <head>
         <meta charset="UTF-8">
         <title>Service error</title>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" class="govuk-template">
     <head>
         <meta charset="UTF-8">
         <title>Page not found</title>

--- a/src/main/resources/templates/privacy-policy.html
+++ b/src/main/resources/templates/privacy-policy.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" class="govuk-template">
 <head>
     <meta charset="UTF-8">
     <link rel="stylesheet" th:href="@{/webjars/govuk-frontend/4.5.0/govuk-frontend.min.css}"/>

--- a/src/main/resources/templates/register-user.html
+++ b/src/main/resources/templates/register-user.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" class="govuk-template">
     <head>
         <meta charset="UTF-8">
         <title th:text="${#fields.hasErrors('${user.*}') ? 'Error: ' : ''}  +  'Register to apply for a grant'"></title>

--- a/src/main/resources/templates/registration-success.html
+++ b/src/main/resources/templates/registration-success.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" class="govuk-template">
 <head>
     <meta charset="UTF-8">
     <title>Register</title>

--- a/src/main/resources/templates/session-expired.html
+++ b/src/main/resources/templates/session-expired.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" class="govuk-template">
     <head>
         <meta charset="UTF-8">
         <title>Session expired</title>

--- a/src/main/resources/templates/updated-email.html
+++ b/src/main/resources/templates/updated-email.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" class="govuk-template">
 <head>
     <meta charset="UTF-8">
     <title>Update Email</title>


### PR DESCRIPTION
## Description

Adding the govuk-template class to the root of all HTML pages served up by user-service to prevent whitespace appearing below pages with only a small bit of content.

## Type of change

Please check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [X] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
