### PR TITLE
GAP-2097: add getEmailFromSub

### DIFF
--- a/src/main/java/gov/cabinetofice/gapuserservice/web/UserController.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/UserController.java
@@ -80,6 +80,11 @@ public class UserController {
         return ResponseEntity.ok(new UserAndRelationsDto(oneLoginUserService.getUserByUserSub(userSub)));
     }
 
+    @GetMapping("/user/{userSub}/email")
+    public ResponseEntity<String> getEmailFromSub(HttpServletRequest httpRequest, @PathVariable("userSub") String userSub) {
+        return ResponseEntity.ok(oneLoginUserService.getUserBySub(userSub).getEmailAddress());
+    }
+
     @PatchMapping("/user/{userId}/department")
     public ResponseEntity<User> updateDepartment(HttpServletRequest httpRequest, @PathVariable("userId") Integer userId,
                                                    @Validated @RequestBody ChangeDepartmentDto changeDepartmentDto) {
@@ -166,7 +171,5 @@ public class UserController {
                         .orElseGet(() -> new UserDto(oneLoginUserService.getUserByEmail(email)))
         );
     }
-
-
 }
 

--- a/src/test/java/gov/cabinetofice/gapuserservice/web/UserControllerTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/web/UserControllerTest.java
@@ -3,6 +3,7 @@ package gov.cabinetofice.gapuserservice.web;
 import gov.cabinetofice.gapuserservice.dto.*;
 import gov.cabinetofice.gapuserservice.exceptions.ForbiddenException;
 import gov.cabinetofice.gapuserservice.exceptions.InvalidRequestException;
+import gov.cabinetofice.gapuserservice.exceptions.UserNotFoundException;
 import gov.cabinetofice.gapuserservice.model.Role;
 import gov.cabinetofice.gapuserservice.model.RoleEnum;
 import gov.cabinetofice.gapuserservice.model.User;
@@ -252,4 +253,29 @@ class UserControllerTest {
         assertThat(methodResponse.getBody()).isEqualTo(mockUserDto);
     }
 
+    @Test
+    void testGetEmailFromSub() {
+        String userSub = "1";
+        String userEmail = "test@test.com";
+        User mockUser = User.builder().sub(userSub).gapUserId(1)
+                .emailAddress(userEmail).build();
+        when(oneLoginUserService.getUserBySub(userSub)).thenReturn(mockUser);
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        final ResponseEntity<String> methodResponse = controller.getEmailFromSub(mockRequest, userSub);
+
+        assertThat(methodResponse.getBody()).isEqualTo(userEmail);
+        verify(oneLoginUserService, times(1)).getUserBySub(userSub);
+    }
+
+    @Test
+    void testGetEmailFromSub_UserNotFound() {
+        String userSub = "2";
+        when(oneLoginUserService.getUserBySub(userSub)).thenThrow(UserNotFoundException.class);
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+
+        assertThrows(UserNotFoundException.class, () -> {
+            controller.getEmailFromSub(mockRequest, userSub);
+        });
+        verify(oneLoginUserService, times(1)).getUserBySub(userSub);
+    }
 }


### PR DESCRIPTION
## Description

Adds a route to provide an emailaddress from a sub. This is used in the applicant back-end when generating a submission summary odt file

https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2097

related prs: 
https://github.com/cabinetoffice/gap-find-applicant-backend/pull/89
https://github.com/cabinetoffice/gap-find-apply-web/pull/246

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
