### PR TITLE
Feat/gap 2424

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,11 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>33.1.0-jre</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>

--- a/src/main/java/gov/cabinetofice/gapuserservice/config/KmsClientConfig.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/config/KmsClientConfig.java
@@ -1,0 +1,21 @@
+package gov.cabinetofice.gapuserservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kms.KmsClient;
+
+@Configuration
+public class KmsClientConfig {
+
+    private final KmsClient kmsClient;
+
+    public KmsClientConfig() {
+        this.kmsClient = KmsClient.builder().region(Region.EU_WEST_2).build();
+    }
+
+    @Bean
+    public KmsClient getKmsClient() {
+        return kmsClient;
+    }
+}

--- a/src/main/java/gov/cabinetofice/gapuserservice/dto/JwtHeader.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/dto/JwtHeader.java
@@ -1,0 +1,23 @@
+package gov.cabinetofice.gapuserservice.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JwtHeader {
+
+    @JsonProperty("kid")
+    private String kid;
+
+    @JsonProperty("typ")
+    private String typ;
+
+    @JsonProperty("alg")
+    private String alg;
+}

--- a/src/main/java/gov/cabinetofice/gapuserservice/security/JwtTokenFilter.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/security/JwtTokenFilter.java
@@ -40,10 +40,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
                                     final @NonNull FilterChain chain)
             throws ServletException, IOException {
         if (Objects.equals(profile, "LOCAL") && debugProperties.isIgnoreJwt()) {
-            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                    "Placeholder",
-                    null,
-                    Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
+            UsernamePasswordAuthenticationToken authentication = getUsernamePasswordAuthenticationToken();
 
             SecurityContextHolder.getContext().setAuthentication(authentication);
             chain.doFilter(request, response);
@@ -82,6 +79,20 @@ public class JwtTokenFilter extends OncePerRequestFilter {
 
         SecurityContextHolder.getContext().setAuthentication(userAuthentication);
         chain.doFilter(request, response);
+    }
+
+    private static UsernamePasswordAuthenticationToken getUsernamePasswordAuthenticationToken() {
+        List<SimpleGrantedAuthority> roles = Arrays.asList(
+                new SimpleGrantedAuthority("ROLE_FIND"),
+                new SimpleGrantedAuthority("ROLE_APPLICANT"),
+                new SimpleGrantedAuthority("ROLE_TECH_SUPPORT_USER"),
+                new SimpleGrantedAuthority("ROLE_ADMIN"),
+                new SimpleGrantedAuthority("ROLE_SUPER_ADMIN")
+                );
+        return new UsernamePasswordAuthenticationToken(
+                "Placeholder",
+                null,
+                roles);
     }
 
 }

--- a/src/main/java/gov/cabinetofice/gapuserservice/security/WebSecurityConfig.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/security/WebSecurityConfig.java
@@ -54,7 +54,6 @@ public class WebSecurityConfig {
                 "/is-user-logged-in",
                 "/redirect-after-cola-login",
                 "/error/**",
-                "/.well-known/jwks.json",
                 "/v2/validateSessionsRoles",
                 "/user",
                 "/users/emails"

--- a/src/main/java/gov/cabinetofice/gapuserservice/service/jwt/impl/CustomJwtServiceImpl.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/service/jwt/impl/CustomJwtServiceImpl.java
@@ -13,7 +13,6 @@ import gov.cabinetofice.gapuserservice.config.JwtProperties;
 import gov.cabinetofice.gapuserservice.dto.JwtHeader;
 import gov.cabinetofice.gapuserservice.dto.JwtPayload;
 import gov.cabinetofice.gapuserservice.enums.LoginJourneyState;
-import gov.cabinetofice.gapuserservice.exceptions.TokenNotValidException;
 import gov.cabinetofice.gapuserservice.exceptions.UnauthorizedException;
 import gov.cabinetofice.gapuserservice.model.Role;
 import gov.cabinetofice.gapuserservice.model.User;
@@ -42,7 +41,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -92,8 +90,8 @@ public class CustomJwtServiceImpl implements JwtService {
     public boolean handleTokenVerification(String token) {
         try {
             return memoizationCache.get(token, () -> verifyToken(token));
-        } catch (ExecutionException e) {
-            throw new TokenNotValidException("Unable to determine token validity: ".concat(e.getMessage()));
+        } catch (Exception e) {
+            throw new JWTVerificationException("Unable to determine token validity: ".concat(e.getMessage()));
         }
     }
 
@@ -117,7 +115,7 @@ public class CustomJwtServiceImpl implements JwtService {
             boolean verifyResponse = handleTokenVerification(customJwt);
 
             if(Boolean.FALSE.equals(verifyResponse)) {
-                throw new TokenNotValidException("JWT Token is not valid");
+                throw new JWTVerificationException("Token could not be verified by KMS: ".concat(customJwt));
             }
 
             if (oneLoginEnabled) {

--- a/src/main/java/gov/cabinetofice/gapuserservice/web/LoginController.java
+++ b/src/main/java/gov/cabinetofice/gapuserservice/web/LoginController.java
@@ -179,12 +179,4 @@ public class LoginController {
         return ResponseEntity.ok(isJwtValid);
     }
 
-
-    @GetMapping("/.well-known/jwks.json")
-    public ResponseEntity<Map<String, Object>> test() {
-        JWKSet jwkset = this.customJwtService.getPublicJWKSet();
-        return ResponseEntity.ok(jwkset.toJSONObject(true));
-    }
-
-
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -47,6 +47,7 @@ jwt.issuer=http://localhost:8082
 jwt.audience=FGP
 jwt.cookie-name=user-service-token
 jwt.cookie-domain=localhost
+jwt.memoization-cache-expiry=20
 
 #One Login properties
 onelogin.client-id=clientIdValue

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -79,9 +79,6 @@ aws.kms.key.arn=arnValue
 aws.kms.origin=eu-west-2
 aws.kms.stage=local
 aws.kms.signing-key.arn=arnValue
-aws.kms.signing-key.origin=eu-west-2
-aws.kms.signing-key.stage=local
-
 
 # Spotlight properties
 feature.spotlight.enabled=

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -77,6 +77,9 @@ feature.find-accounts.migration.enabled=true
 aws.kms.key.arn=arnValue
 aws.kms.origin=eu-west-2
 aws.kms.stage=local
+aws.kms.signing-key.arn=arnValue
+aws.kms.signing-key.origin=eu-west-2
+aws.kms.signing-key.stage=local
 
 
 # Spotlight properties

--- a/src/test/java/gov/cabinetofice/gapuserservice/service/jwt/CustomJwtServiceImplTest.java
+++ b/src/test/java/gov/cabinetofice/gapuserservice/service/jwt/CustomJwtServiceImplTest.java
@@ -1,12 +1,9 @@
 package gov.cabinetofice.gapuserservice.service.jwt;
 
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.JWTCreator;
-import com.auth0.jwt.JWTVerifier;
-import com.auth0.jwt.algorithms.Algorithm;
-import com.auth0.jwt.exceptions.JWTVerificationException;
-import com.auth0.jwt.interfaces.Verification;
-import com.nimbusds.jose.JOSEException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.cache.Cache;
 import gov.cabinetofice.gapuserservice.config.JwtProperties;
 import gov.cabinetofice.gapuserservice.dto.JwtPayload;
 import gov.cabinetofice.gapuserservice.enums.LoginJourneyState;
@@ -25,10 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -37,19 +31,21 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SignResponse;
+import software.amazon.awssdk.services.kms.model.VerifyRequest;
+import software.amazon.awssdk.services.kms.model.VerifyResponse;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 
-import static com.auth0.jwt.JWT.decode;
-import static com.auth0.jwt.JWT.require;
-import static com.auth0.jwt.algorithms.Algorithm.RSA256;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 
@@ -67,16 +63,19 @@ public class CustomJwtServiceImplTest {
 
     @Mock
     private UserRepository userRepository;
-    
+
     @Mock
     private KmsClient kmsClient;
+
+    @Captor
+    private ArgumentCaptor<SignRequest> signRequestCaptor;
 
     private final String CHRISTMAS_2022_MIDDAY = "2022-12-25T12:00:00.00z";
     private final Clock clock = Clock.fixed(Instant.parse(CHRISTMAS_2022_MIDDAY), ZoneId.of("UTC"));
     private static MockedStatic<WebUtils> mockedWebUtils;
 
     @BeforeEach
-    void setup() throws JOSEException {
+    void setup() {
         mockedWebUtils = mockStatic(WebUtils.class);
         final JwtProperties jwtProperties = JwtProperties.builder()
                 .signingKey("test-signing-key")
@@ -98,160 +97,90 @@ public class CustomJwtServiceImplTest {
 
     @Nested
     class IsTokenValid {
-        @Mock
-        private final JWTVerifier mockedJwtVerifier = mock(JWTVerifier.class);
-        final Algorithm mockAlgorithm = mock(Algorithm.class);
-        private final Verification verification = JWT.require(mockAlgorithm);
-
         final String jwt = "eyJraWQiOiIxODNjZTQ5YS0xYjExLTRiYjgtOWExMi1iYTViNzVmNGVmZjQiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOmliZDJyejJDZ3lpZG5kWHlxMnp5ZmNuUXd5WUk1N2gzNHZNbFNyODdDRGYiLCJhdWQiOiJGR1AiLCJpZFRva2VuIjoienFybiIsInJvbGVzIjoiW0FQUExJQ0FOVCwgRklORCwgQURNSU4sIFNVUEVSX0FETUlOXSIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MiIsImRlcGFydG1lbnQiOiJDYWJpbmV0IE9mZmljZSIsImV4cCI6MTY5MDQ1MjkzNCwiaWF0IjoxNjkwNDQ5MzM0LCJlbWFpbCI6InRlc3QudXNlckBnb3YudWsiLCJqdGkiOiIxOWQyMGYzMi0xZDIyLTQ0NzgtYjkwNi0wMzc5Mzg5ODUxODMifQ.H0xj5yob8u7eJs8zaCgjlTm_pt4fKrNhzFsmMcBNHghUaK3SQUoJcjUea31rKFppl5Dju90lq7n1fmNhVAk3Hpli6KvU2KNSgJZbCiMU5PbjJRZ3ogssjYjhOvor7fQrpComwZqA5-1I2jq9bQEIBwMyoSIpEJh1XFnk_GexedhlTY3ws0C9pX5gev7TL13cuc7xMRDRQE2G6-0sSOdTc5z0ib-Xjqz7D6tkLSOZJ4EKrbNnXpfar8KTSAUX6bO8Huj8q-FousOTpnlgOuUtNWXgdL928wP3fHgaCKsiALCDoHfoRSK2-0do0rsMmFHIrnIeZkJqvULgjgd55FLsAg";
 
 
         @Test
-        void ReturnsTrue_IfValid() {
-            final Algorithm mockAlgorithm = mock(Algorithm.class);
-            final Verification spiedVerification = spy(verification);
-            ReflectionTestUtils.setField(serviceUnderTest, "oneLoginEnabled", true);
-
-            try (MockedStatic<Algorithm> staticAlgorithm = Mockito.mockStatic(Algorithm.class)) {
-                staticAlgorithm.when(() -> RSA256(any(), any())).thenReturn(mockAlgorithm);
-                try (MockedStatic<JWT> staticJwt = Mockito.mockStatic(JWT.class)) {
-                    staticJwt.when(() -> require(any())).thenReturn(spiedVerification);
-                    staticJwt.when(() -> decode(any())).thenCallRealMethod();
-                    when(spiedVerification.build()).thenReturn(mockedJwtVerifier);
-                    User testUser = User.builder().roles(List.of(Role.builder().name(RoleEnum.FIND).id(1).build(), Role.builder().name(RoleEnum.SUPER_ADMIN).id(4).build(), Role.builder().name(RoleEnum.ADMIN).id(3).build(), Role.builder().name(RoleEnum.APPLICANT).id(2).build())).loginJourneyState(LoginJourneyState.USER_READY).build();
-                    when(userRepository.findBySub(any())).thenReturn(Optional.of(testUser));
-                    when(oneLoginUserService.getUserBySub(any())).thenReturn(testUser);
-                    final boolean response = serviceUnderTest.isTokenValid(jwt);
-                    assertThat(response).isTrue();
-                    verify(mockedJwtVerifier, times(1)).verify(jwt);
-                }
-            }
-        }
-
-        @Test
         void shouldNotCallValidateRolesInThePayloadWhenFlagIsDisabled() {
-            final Algorithm mockAlgorithm = mock(Algorithm.class);
-            final Verification spiedVerification = spy(verification);
             ReflectionTestUtils.setField(serviceUnderTest, "validateUserRolesInMiddleware", false);
 
-            try (MockedStatic<Algorithm> staticAlgorithm = Mockito.mockStatic(Algorithm.class)) {
-                staticAlgorithm.when(() -> RSA256(any(), any())).thenReturn(mockAlgorithm);
-                try (MockedStatic<JWT> staticJwt = Mockito.mockStatic(JWT.class)) {
-                    staticJwt.when(() -> require(any())).thenReturn(spiedVerification);
-                    staticJwt.when(() -> decode(any())).thenCallRealMethod();
-                    when(spiedVerification.build()).thenReturn(mockedJwtVerifier);
-                    serviceUnderTest.isTokenValid(jwt);
-                    JwtPayload payload = new JwtPayload();
-                    Mockito.verify(serviceUnderTest, Mockito.never()).validateRolesInThePayload(payload);
-                }
-            }
+            when(kmsClient.verify(any(VerifyRequest.class))).thenReturn(VerifyResponse.builder()
+                    .signatureValid(false)
+                    .build());
+            serviceUnderTest.isTokenValid(jwt);
+            JwtPayload payload = new JwtPayload();
+            Mockito.verify(serviceUnderTest, Mockito.never()).validateRolesInThePayload(payload);
+
         }
 
         @Test
-        void ReturnsFalse_IfInvalid() {
-            final Algorithm mockAlgorithm = mock(Algorithm.class);
-            final Verification spiedVerification = spy(verification);
-
-            try (MockedStatic<Algorithm> staticAlgorithm = Mockito.mockStatic(Algorithm.class)) {
-                staticAlgorithm.when(() -> RSA256(any(), any())).thenReturn(mockAlgorithm);
-                try (MockedStatic<JWT> staticJwt = Mockito.mockStatic(JWT.class)) {
-                    staticJwt.when(() -> require(any())).thenReturn(spiedVerification);
-                    staticJwt.when(() -> decode(any())).thenCallRealMethod();
-                    when(spiedVerification.build()).thenReturn(mockedJwtVerifier);
-                    when(mockedJwtVerifier.verify(jwt)).thenThrow(new JWTVerificationException("An error"));
-
-                    final boolean response = serviceUnderTest.isTokenValid(jwt);
-                    assertThat(response).isFalse();
-                    verify(mockedJwtVerifier, times(1)).verify(jwt);
-                }
-            }
-        }
-
-        @Test
-        void ReturnsFalse_ifInvalidPayload() {
-            final Algorithm mockAlgorithm = mock(Algorithm.class);
-            final Verification spiedVerification = spy(verification);
+        void ReturnsFalse_ifKmsVerificationFails() {
             ReflectionTestUtils.setField(serviceUnderTest, "oneLoginEnabled", true);
+            when(kmsClient.verify(any(VerifyRequest.class))).thenReturn(VerifyResponse.builder()
+                    .signatureValid(false)
+                    .build());
 
-            try (MockedStatic<Algorithm> staticAlgorithm = Mockito.mockStatic(Algorithm.class)) {
-                staticAlgorithm.when(() -> RSA256(any(), any())).thenReturn(mockAlgorithm);
-                try (MockedStatic<JWT> staticJwt = Mockito.mockStatic(JWT.class)) {
-                    staticJwt.when(() -> require(any())).thenReturn(spiedVerification);
-                    staticJwt.when(() -> decode(any())).thenCallRealMethod();
-                    when(spiedVerification.build()).thenReturn(mockedJwtVerifier);
-                    User testUser = User.builder().roles(List.of(Role.builder().name(RoleEnum.FIND).id(1).build(),
-                                    Role.builder().name(RoleEnum.SUPER_ADMIN).id(4).build(),
-                                    Role.builder().name(RoleEnum.ADMIN).id(3).build(),
-                                    Role.builder().name(RoleEnum.APPLICANT).id(2).build()))
-                            .loginJourneyState(LoginJourneyState.USER_READY).build();
-                    when(userRepository.findBySub(any())).thenReturn(Optional.of(testUser));
-                    when(oneLoginUserService.getUserBySub(any())).thenReturn(testUser);
-                    doThrow(UnauthorizedException.class).when(oneLoginUserService).validateRoles(any(), any());
-
-                    final boolean response = serviceUnderTest.isTokenValid(jwt);
-                    assertThat(response).isFalse();
-                    verify(mockedJwtVerifier, times(1)).verify(jwt);
-                }
-            }
+            final boolean response = serviceUnderTest.isTokenValid(jwt);
+            assertThat(response).isFalse();
+            verify(kmsClient, times(1)).verify(any(VerifyRequest.class));
         }
 
         @Test
         void ReturnsFalse_IfBlacklisted() {
-            final Algorithm mockAlgorithm = mock(Algorithm.class);
-            final Verification spiedVerification = spy(verification);
             ReflectionTestUtils.setField(serviceUnderTest, "oneLoginEnabled", true);
 
-            try (MockedStatic<Algorithm> staticAlgorithm = Mockito.mockStatic(Algorithm.class)) {
-                staticAlgorithm.when(() -> RSA256(any(), any())).thenReturn(mockAlgorithm);
-                try (MockedStatic<JWT> staticJwt = Mockito.mockStatic(JWT.class)) {
-                    staticJwt.when(() -> require(any())).thenReturn(spiedVerification);
-                    staticJwt.when(() -> decode(any())).thenCallRealMethod();
-                    when(spiedVerification.build()).thenReturn(mockedJwtVerifier);
-                    when(jwtBlacklistRepository.existsByJwtIs(jwt)).thenReturn(true);
-                    User testUser = User.builder().roles(List.of(Role.builder().name(RoleEnum.FIND).id(1).build(),
-                                    Role.builder().name(RoleEnum.SUPER_ADMIN).id(4).build(),
-                                    Role.builder().name(RoleEnum.ADMIN).id(3).build(),
-                                    Role.builder().name(RoleEnum.APPLICANT).id(2).build()))
-                            .loginJourneyState(LoginJourneyState.USER_READY).build();
-                    when(userRepository.findBySub(any())).thenReturn(Optional.of(testUser));
-                    when(oneLoginUserService.getUserBySub(any())).thenReturn(testUser);
+            when(jwtBlacklistRepository.existsByJwtIs(jwt)).thenReturn(true);
+            User testUser = User.builder().roles(List.of(Role.builder().name(RoleEnum.FIND).id(1).build(),
+                            Role.builder().name(RoleEnum.SUPER_ADMIN).id(4).build(),
+                            Role.builder().name(RoleEnum.ADMIN).id(3).build(),
+                            Role.builder().name(RoleEnum.APPLICANT).id(2).build()))
+                    .loginJourneyState(LoginJourneyState.USER_READY).build();
+            when(userRepository.findBySub(any())).thenReturn(Optional.of(testUser));
+            when(oneLoginUserService.getUserBySub(any())).thenReturn(testUser);
+            when(kmsClient.verify(any(VerifyRequest.class))).thenReturn(VerifyResponse.builder().signatureValid(true)
+                    .build());
 
-                    final boolean response = serviceUnderTest.isTokenValid(jwt);
+            final boolean response = serviceUnderTest.isTokenValid(jwt);
 
-                    assertThat(response).isFalse();
-                    verify(mockedJwtVerifier, times(1)).verify(jwt);
-                    verify(jwtBlacklistRepository, atLeastOnce()).existsByJwtIs(jwt);
-                }
-            }
+            assertThat(response).isFalse();
+            verify(jwtBlacklistRepository, atLeastOnce()).existsByJwtIs(jwt);
         }
 
         @Test
-        void SignsWithCorrectAlgorithm() {
-            final Algorithm mockAlgorithm = mock(Algorithm.class);
-            final Verification spiedVerification = spy(verification);
+        void ReturnsFalse_IfMemoizationFails() throws ExecutionException {
             ReflectionTestUtils.setField(serviceUnderTest, "oneLoginEnabled", true);
 
-            try (MockedStatic<Algorithm> staticAlgorithm = Mockito.mockStatic(Algorithm.class)) {
-                try (MockedStatic<JWT> staticJwt = Mockito.mockStatic(JWT.class)) {
-                    staticJwt.when(() -> require(any())).thenReturn(spiedVerification);
-                    staticJwt.when(() -> decode(any())).thenCallRealMethod();
-                    when(spiedVerification.build()).thenReturn(mockedJwtVerifier);
-                    staticAlgorithm.when(() -> RSA256(any(), any())).thenReturn(mockAlgorithm);
-                    User testUser = User.builder().roles(List.of(Role.builder().name(RoleEnum.FIND).id(1).build(),
-                                    Role.builder().name(RoleEnum.SUPER_ADMIN).id(4).build(),
-                                    Role.builder().name(RoleEnum.ADMIN).id(3).build(),
-                                    Role.builder().name(RoleEnum.APPLICANT).id(2).build()))
-                            .loginJourneyState(LoginJourneyState.USER_READY).build();
-                    when(userRepository.findBySub(any())).thenReturn(Optional.of(
-                            User.builder().loginJourneyState(LoginJourneyState.USER_READY).build()));
-                    when(userRepository.findBySub(any())).thenReturn(Optional.of(testUser));
-                    when(oneLoginUserService.getUserBySub(any())).thenReturn(testUser);
-                    serviceUnderTest.isTokenValid(jwt);
-                    staticAlgorithm.verify(() -> RSA256(any(), any()), times(1));
-                    staticJwt.verify(() -> JWT.require(mockAlgorithm), times(1));
-                    verify(mockedJwtVerifier, times(1)).verify(jwt);
-                }
-            }
+            Cache<String, Boolean> memoizationCache = mock(Cache.class);
+            ReflectionTestUtils.setField(serviceUnderTest, "memoizationCache", memoizationCache);
+
+            when(memoizationCache.get(any(), any())).thenThrow(new RuntimeException("Test execution exception"));
+
+            final boolean response = serviceUnderTest.isTokenValid(jwt);
+
+            assertThat(response).isFalse();
+        }
+
+
+        @Test
+        void ReturnsTrue_IfValid() {
+            ReflectionTestUtils.setField(serviceUnderTest, "oneLoginEnabled", true);
+
+            User testUser = User.builder().roles(List.of(Role.builder().name(RoleEnum.FIND).id(1).build(),
+                            Role.builder().name(RoleEnum.SUPER_ADMIN).id(4).build(),
+                            Role.builder().name(RoleEnum.ADMIN).id(3).build(),
+                            Role.builder().name(RoleEnum.APPLICANT).id(2).build()))
+                    .loginJourneyState(LoginJourneyState.USER_READY).build();
+            when(userRepository.findBySub(any())).thenReturn(Optional.of(
+                    User.builder().loginJourneyState(LoginJourneyState.USER_READY).build()));
+            when(userRepository.findBySub(any())).thenReturn(Optional.of(testUser));
+            when(oneLoginUserService.getUserBySub(any())).thenReturn(testUser);
+
+            when(kmsClient.verify(any(VerifyRequest.class))).thenReturn(VerifyResponse.builder().signatureValid(true)
+                    .build());
+            boolean response = serviceUnderTest.isTokenValid(jwt);
+
+            verify(kmsClient, times(1)).verify(any(VerifyRequest.class));
+            assertTrue(response);
         }
     }
 
@@ -259,143 +188,88 @@ public class CustomJwtServiceImplTest {
     class GenerateToken {
 
         @Test
-        void WithCorrectIssuer() {
-            final JWTCreator.Builder mockedJwtBuilder = spy(JWTCreator.Builder.class);
+        void shouldReturnValidToken() throws JsonProcessingException {
             final Map<String, String> claims = new HashMap<>();
             claims.put("test-claim-key", "test-claim-value");
 
-            try (MockedStatic<JWT> staticJwt = Mockito.mockStatic(JWT.class)) {
-                staticJwt.when(JWT::create).thenReturn(mockedJwtBuilder);
-                when(kmsClient.sign(any(SignRequest.class))).thenReturn(SignResponse.builder()
-                        .signature(SdkBytes.fromString("abc", StandardCharsets.UTF_8)).build());
-                serviceUnderTest.generateToken(claims);
+            when(kmsClient.sign(any(SignRequest.class))).thenReturn(SignResponse.builder()
+                    .signature(SdkBytes.fromString("abc", StandardCharsets.UTF_8)).build());
 
-                verify(mockedJwtBuilder, times(1)).withIssuer("test-issuer");
+            String response = serviceUnderTest.generateToken(claims);
+
+            verify(kmsClient).sign(signRequestCaptor.capture());
+            SignRequest capturedSignRequest = signRequestCaptor.getValue();
+            String message = SdkBytes.fromByteArray(capturedSignRequest.message().asByteArray()).asString(StandardCharsets.UTF_8);
+
+            assertEquals("RSASSA_PSS_SHA_256", capturedSignRequest.signingAlgorithm().name());
+            assertEquals("RAW", capturedSignRequest.messageType().name());
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            ObjectNode jsonObject = objectMapper.readValue(message, ObjectNode.class);
+
+            assertNotNull(response);
+            assertEquals("test-audience", jsonObject.get("aud").asText());
+            assertEquals("test-issuer", jsonObject.get("iss").asText());
+            assertEquals("1671973200", jsonObject.get("exp").asText());
+            assertEquals("test-claim-value", jsonObject.get("test-claim-key").asText());
+            assertNotNull(jsonObject.get("iat").asText());
+        }
+
+        @Nested
+        class ValidateRolesInTheyPayload {
+            @Test
+            void testValidateRolesInThePayloadWithValidPayload() {
+                User testUser = User.builder().gapUserId(1).sub("sub").build();
+                JwtPayload payload = new JwtPayload();
+                payload.setRoles("[FIND, APPLY]");
+                when(oneLoginUserService.getUserBySub(any())).thenReturn(testUser);
+                doNothing().when(oneLoginUserService).validateRoles(testUser.getRoles(), "[FIND, APPLY]");
+                JwtPayload response = serviceUnderTest.validateRolesInThePayload(payload);
+
+                assertThat(response).isSameAs(payload);
+            }
+
+            @Test
+            void testValidateRolesInThePayloadWithInvalidPayload() {
+                User testUser = User.builder().gapUserId(1).sub("sub").build();
+                when(oneLoginUserService.getUserBySub(any())).thenReturn(testUser);
+                JwtPayload payload = new JwtPayload();
+                payload.setRoles("[FIND, APPLY]");
+                doThrow(UnauthorizedException.class).when(oneLoginUserService)
+                        .validateRoles(testUser.getRoles(), "[FIND, APPLY]");
+
+                assertThrows(UnauthorizedException.class, () -> serviceUnderTest.validateRolesInThePayload(payload));
             }
         }
 
-        @Test
-        void WithCorrectAudience() {
-            final JWTCreator.Builder mockedJwtBuilder = spy(JWTCreator.Builder.class);
-            final Map<String, String> claims = new HashMap<>();
-            claims.put("test-claim-key", "test-claim-value");
-            try (MockedStatic<JWT> staticJwt = Mockito.mockStatic(JWT.class)) {
-                staticJwt.when(JWT::create).thenReturn(mockedJwtBuilder);
+        @Nested
+        class GetUserFromJwt {
+            @Test
+            void testGetUserFromJwtWithValidJwt() {
+                String validJwt = "eyJraWQiOiIxODNjZTQ5YS0xYjExLTRiYjgtOWExMi1iYTViNzVmNGVmZjQiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOmliZDJyejJDZ3lpZG5kWHlxMnp5ZmNuUXd5WUk1N2gzNHZNbFNyODdDRGYiLCJhdWQiOiJGR1AiLCJpZFRva2VuIjoienFybiIsInJvbGVzIjoiW0FQUExJQ0FOVCwgRklORCwgQURNSU4sIFNVUEVSX0FETUlOXSIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MiIsImRlcGFydG1lbnQiOiJDYWJpbmV0IE9mZmljZSIsImV4cCI6MTY5MDQ1MjkzNCwiaWF0IjoxNjkwNDQ5MzM0LCJlbWFpbCI6InRlc3QudXNlckBnb3YudWsiLCJqdGkiOiIxOWQyMGYzMi0xZDIyLTQ0NzgtYjkwNi0wMzc5Mzg5ODUxODMifQ.H0xj5yob8u7eJs8zaCgjlTm_pt4fKrNhzFsmMcBNHghUaK3SQUoJcjUea31rKFppl5Dju90lq7n1fmNhVAk3Hpli6KvU2KNSgJZbCiMU5PbjJRZ3ogssjYjhOvor7fQrpComwZqA5-1I2jq9bQEIBwMyoSIpEJh1XFnk_GexedhlTY3ws0C9pX5gev7TL13cuc7xMRDRQE2G6-0sSOdTc5z0ib-Xjqz7D6tkLSOZJ4EKrbNnXpfar8KTSAUX6bO8Huj8q-FousOTpnlgOuUtNWXgdL928wP3fHgaCKsiALCDoHfoRSK2-0do0rsMmFHIrnIeZkJqvULgjgd55FLsAg";
+                final MockHttpServletRequest request = new MockHttpServletRequest();
+                User testUser = User.builder().gapUserId(1).sub("sub").build();
+                Cookie cookie = new Cookie("userServiceCookieName", validJwt);
+                mockedWebUtils.when(() -> WebUtils.getCookie(request, "userServiceCookieName"))
+                        .thenReturn(cookie);
+                when(userRepository.findBySub(any())).thenReturn(Optional.of(testUser));
+                Optional<User> response = serviceUnderTest.getUserFromJwt(request);
 
-                serviceUnderTest.generateToken(claims);
-
-                verify(mockedJwtBuilder, times(1)).withAudience("test-audience");
+                assertThat(response).isEqualTo(Optional.of(testUser));
             }
-        }
 
-        @Test
-        void WithCorrectExpiration() {
-            final JWTCreator.Builder mockedJwtBuilder = spy(JWTCreator.Builder.class);
-            final long now = ZonedDateTime.now(clock).toInstant().toEpochMilli();
-            final Map<String, String> claims = new HashMap<>();
-            claims.put("test-claim-key", "test-claim-value");
-
-            try (MockedStatic<JWT> staticJwt = Mockito.mockStatic(JWT.class)) {
-                staticJwt.when(JWT::create).thenReturn(mockedJwtBuilder);
-
-                serviceUnderTest.generateToken(claims);
-
-                verify(mockedJwtBuilder, times(1)).withExpiresAt(new Date(now + 60 * 1000 * 60));
+            @Test
+            void testGetUserFromJwtThrowsUnauthorizedWithNullJwt() {
+                HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+                assertThrows(UnauthorizedException.class, () -> serviceUnderTest.getUserFromJwt(mockRequest));
             }
-        }
 
-        @Test
-        void WithCorrectSigningKey() {
-            final JWTCreator.Builder mockedJwtBuilder = spy(JWTCreator.Builder.class);
-            final Algorithm mockAlgorithm = mock(Algorithm.class);
-            final Map<String, String> claims = new HashMap<>();
-            claims.put("test-claim-key", "test-claim-value");
-
-            try (MockedStatic<Algorithm> staticAlgorithm = Mockito.mockStatic(Algorithm.class)) {
-                try (MockedStatic<JWT> staticJwt = Mockito.mockStatic(JWT.class)) {
-                    staticJwt.when(JWT::create).thenReturn(mockedJwtBuilder);
-                    staticAlgorithm.when(() -> RSA256(any(), any())).thenReturn(mockAlgorithm);
-                    doReturn("a-custom-jwt").when(mockedJwtBuilder).sign(mockAlgorithm);
-
-                    serviceUnderTest.generateToken(claims);
-
-                    staticAlgorithm.verify(() -> RSA256(any(), any()), times(1));
-                    verify(mockedJwtBuilder, times(1)).sign(mockAlgorithm);
-                }
+            @Test
+            void testGetUserFromJwtWithNullValueInJwt() {
+                HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+                when(WebUtils.getCookie(mockRequest, "userServiceCookieName")).thenReturn(null);
+                assertThrows(UnauthorizedException.class, () -> serviceUnderTest.getUserFromJwt(mockRequest));
             }
-        }
-
-        @Test
-        void ReturnsACustomJwt() {
-            final JWTCreator.Builder mockedJwtBuilder = spy(JWTCreator.Builder.class);
-            final Map<String, String> claims = new HashMap<>();
-            claims.put("test-claim-key", "test-claim-value");
-
-            try (MockedStatic<JWT> staticJwt = Mockito.mockStatic(JWT.class)) {
-                staticJwt.when(JWT::create).thenReturn(mockedJwtBuilder);
-                doReturn("a-custom-jwt").when(mockedJwtBuilder).sign(any());
-
-                final String response = serviceUnderTest.generateToken(claims);
-
-                assertThat(response).isEqualTo("a-custom-jwt");
-            }
-        }
-    }
-
-    @Nested
-    class ValidateRolesInTheyPayload {
-        @Test
-        void testValidateRolesInThePayloadWithValidPayload() {
-            User testUser = User.builder().gapUserId(1).sub("sub").build();
-            JwtPayload payload = new JwtPayload();
-            payload.setRoles("[FIND, APPLY]");
-            when(oneLoginUserService.getUserBySub(any())).thenReturn(testUser);
-            doNothing().when(oneLoginUserService).validateRoles(testUser.getRoles(), "[FIND, APPLY]");
-            JwtPayload response = serviceUnderTest.validateRolesInThePayload(payload);
-
-            assertThat(response).isSameAs(payload);
-        }
-
-        @Test
-        void testValidateRolesInThePayloadWithInvalidPayload() {
-            User testUser = User.builder().gapUserId(1).sub("sub").build();
-            when(oneLoginUserService.getUserBySub(any())).thenReturn(testUser);
-            JwtPayload payload = new JwtPayload();
-            payload.setRoles("[FIND, APPLY]");
-            doThrow(UnauthorizedException.class).when(oneLoginUserService)
-                    .validateRoles(testUser.getRoles(), "[FIND, APPLY]");
-
-            assertThrows(UnauthorizedException.class, () -> serviceUnderTest.validateRolesInThePayload(payload));
-        }
-    }
-
-    @Nested
-    class GetUserFromJwt {
-        @Test
-        void testGetUserFromJwtWithValidJwt() {
-            String validJwt = "eyJraWQiOiIxODNjZTQ5YS0xYjExLTRiYjgtOWExMi1iYTViNzVmNGVmZjQiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOmliZDJyejJDZ3lpZG5kWHlxMnp5ZmNuUXd5WUk1N2gzNHZNbFNyODdDRGYiLCJhdWQiOiJGR1AiLCJpZFRva2VuIjoienFybiIsInJvbGVzIjoiW0FQUExJQ0FOVCwgRklORCwgQURNSU4sIFNVUEVSX0FETUlOXSIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MiIsImRlcGFydG1lbnQiOiJDYWJpbmV0IE9mZmljZSIsImV4cCI6MTY5MDQ1MjkzNCwiaWF0IjoxNjkwNDQ5MzM0LCJlbWFpbCI6InRlc3QudXNlckBnb3YudWsiLCJqdGkiOiIxOWQyMGYzMi0xZDIyLTQ0NzgtYjkwNi0wMzc5Mzg5ODUxODMifQ.H0xj5yob8u7eJs8zaCgjlTm_pt4fKrNhzFsmMcBNHghUaK3SQUoJcjUea31rKFppl5Dju90lq7n1fmNhVAk3Hpli6KvU2KNSgJZbCiMU5PbjJRZ3ogssjYjhOvor7fQrpComwZqA5-1I2jq9bQEIBwMyoSIpEJh1XFnk_GexedhlTY3ws0C9pX5gev7TL13cuc7xMRDRQE2G6-0sSOdTc5z0ib-Xjqz7D6tkLSOZJ4EKrbNnXpfar8KTSAUX6bO8Huj8q-FousOTpnlgOuUtNWXgdL928wP3fHgaCKsiALCDoHfoRSK2-0do0rsMmFHIrnIeZkJqvULgjgd55FLsAg";
-            final MockHttpServletRequest request = new MockHttpServletRequest();
-            User testUser = User.builder().gapUserId(1).sub("sub").build();
-            Cookie cookie = new Cookie("userServiceCookieName", validJwt);
-            mockedWebUtils.when(() -> WebUtils.getCookie(request, "userServiceCookieName"))
-                    .thenReturn(cookie);
-            when(userRepository.findBySub(any())).thenReturn(Optional.of(testUser));
-            Optional<User> response = serviceUnderTest.getUserFromJwt(request);
-
-            assertThat(response).isEqualTo(Optional.of(testUser));
-        }
-
-        @Test
-        void testGetUserFromJwtThrowsUnauthorizedWithNullJwt() {
-            HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-            assertThrows(UnauthorizedException.class, () -> serviceUnderTest.getUserFromJwt(mockRequest));
-        }
-
-        @Test
-        void testGetUserFromJwtWithNullValueInJwt() {
-            HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-            when(WebUtils.getCookie(mockRequest, "userServiceCookieName")).thenReturn(null);
-            assertThrows(UnauthorizedException.class, () -> serviceUnderTest.getUserFromJwt(mockRequest));
         }
     }
 }


### PR DESCRIPTION
## Description

This change strips out the old jwt sign and verification logic that we did manually by creating our own rsa key upon startup. We now will use kms to do this ensuring the app can be horizontally scaled.

Uses memoziation to cache response from kms so that we are not spamming it. Local testing showed that we check token validity A LOT so this is a measure to reduce AWS cost

Ticket # and link

https://technologyprogramme.atlassian.net/browse/GAP-2424

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [x] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
