### PR TITLE
Gap 2587/redirect to404when not allowed on a page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ This service manages users for The Cabinet Office's Apply for a Grant service
 - run `colima start`
 - run `docker pull postgres`
 - run `docker run -itd -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=mysecretpassword -p 5432:5432 --name postgres-local postgres`
+- connect to the database using pgaAdmin or any other DMS and seed the database with the script you can find in src/main/resources/db/Users-setup-LOCAL.sql
 - NOTE: to start this container AFTER the first time you run this command, just use `docker start postgres-local`
 Install PGAdmin either through docker or directly onto your system then connect to the instance of Postgres you’ve just started:
   - host: `localhost` or `127.0.0.1` (or `host.docker.internal` if you also run PGAdmin with docker)
   - port: `5432`
   - username: `postgres`
   - password: `mysecretpassword`
+
 
 ### Database Setup without Docker
 - Install postgres and pgadmin
@@ -30,6 +32,7 @@ Install PGAdmin either through docker or directly onto your system then connect 
 - update your application.properties database username and password. Default user/pass for the `postgres` user is `postgres`/`postgres`
   - spring.datasource.username
   - spring.datasource.password
+- seed the database with the script you can find in src/main/resources/db/Users-setup-LOCAL.sql
   
 ### Wiremock
 

--- a/mockOneLogin/wiremock/__files/onelogin-tech-supporter-userinfo-response-get.json
+++ b/mockOneLogin/wiremock/__files/onelogin-tech-supporter-userinfo-response-get.json
@@ -1,0 +1,5 @@
+{
+  "sub": "urn:fdc:gov.uk:2022:ibd2rz2CgyidndXyq2zyfcnQwyYI57h34vMlSr00Sup",
+  "email_verified": true,
+  "email": "test.tech-supporter@gov.uk"
+}

--- a/src/main/java/gov/cabinetoffice/gapuserservice/util/WebUtil.java
+++ b/src/main/java/gov/cabinetoffice/gapuserservice/util/WebUtil.java
@@ -66,7 +66,7 @@ public class WebUtil {
     }
 
     public static void validateRedirectUrl(final String inputUrl, final String baseUrl) throws MalformedURLException {
-        if(inputUrl.endsWith("/404")){
+        if (inputUrl.endsWith("/404")) {
             return;
         }
         URL url = new URL(inputUrl);

--- a/src/main/java/gov/cabinetoffice/gapuserservice/util/WebUtil.java
+++ b/src/main/java/gov/cabinetoffice/gapuserservice/util/WebUtil.java
@@ -66,6 +66,9 @@ public class WebUtil {
     }
 
     public static void validateRedirectUrl(final String inputUrl, final String baseUrl) throws MalformedURLException {
+        if(inputUrl.endsWith("/404")){
+            return;
+        }
         URL url = new URL(inputUrl);
         String inputUrlHost = url.getProtocol() + "://" + url.getHost();
         if (!baseUrl.startsWith(inputUrlHost)) {

--- a/src/main/java/gov/cabinetoffice/gapuserservice/web/LoginControllerV2.java
+++ b/src/main/java/gov/cabinetoffice/gapuserservice/web/LoginControllerV2.java
@@ -7,7 +7,9 @@ import gov.cabinetoffice.gapuserservice.config.FindAGrantConfigProperties;
 import gov.cabinetoffice.gapuserservice.dto.*;
 import gov.cabinetoffice.gapuserservice.enums.GetRedirectUrlArgs;
 import gov.cabinetoffice.gapuserservice.enums.NextStateArgs;
+import gov.cabinetoffice.gapuserservice.exceptions.RoleNotFoundException;
 import gov.cabinetoffice.gapuserservice.exceptions.UserNotFoundException;
+import gov.cabinetoffice.gapuserservice.model.RoleEnum;
 import gov.cabinetoffice.gapuserservice.model.User;
 import gov.cabinetoffice.gapuserservice.service.OneLoginService;
 import gov.cabinetoffice.gapuserservice.service.encryption.Sha512Service;
@@ -26,6 +28,7 @@ import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
@@ -34,6 +37,7 @@ import org.springframework.web.servlet.view.RedirectView;
 import org.springframework.web.util.WebUtils;
 
 import java.net.MalformedURLException;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -53,6 +57,7 @@ public class LoginControllerV2 {
     private final OneLoginUserService oneLoginUserService;
     private final FindAGrantConfigProperties findProperties;
     private final LoggingUtils loggingUtils;
+
 
     public static final String PRIVACY_POLICY_PAGE_VIEW = "privacy-policy";
 
@@ -101,7 +106,7 @@ public class LoginControllerV2 {
                 && customJWTCookie.getValue() != null
                 && customJwtService.isTokenValid(customJWTCookie.getValue());
         String redirectUrl = redirectUrlParam.orElse(null);
-        if (redirectUrl != null) {
+        if (redirectUrl != null ) {
             WebUtil.validateRedirectUrl(redirectUrl, findAGrantBaseUrl);
         }
 
@@ -117,7 +122,31 @@ public class LoginControllerV2 {
         if (redirectUrl == null) {
             redirectUrl = configProperties.getDefaultRedirectUrl();
         }
+        if(redirectUrl.endsWith("/404")) {
+            final DecodedJWT decodedJwt = customJwtService.decodedJwt(customJWTCookie.getValue());
+            final JwtPayload payload = customJwtService.decodeTheTokenPayloadInAReadableFormat(decodedJwt);
+            final List<String> roles = List.of(payload.getRoles()
+                    .replace("[", "")
+                    .replace("]", "")
+                    .replace(" ", "")
+                    .split(","));
+
+            redirectUrl = generate404UrlBasedOnHighestRole(roles);
+
+            return new RedirectView(redirectUrl);
+        }
         return new RedirectView(redirectUrl);
+    }
+
+    private String generate404UrlBasedOnHighestRole(List<String> roles) {
+        final String PAGE_404 = "/404";
+        if (roles.contains(RoleEnum.SUPER_ADMIN.name()) || roles.contains(RoleEnum.ADMIN.name()))
+            return adminBaseUrl + PAGE_404;
+        if (roles.contains(RoleEnum.TECHNICAL_SUPPORT.name()))
+            return techSupportAppBaseUrl + PAGE_404;
+        if (roles.contains(RoleEnum.APPLICANT.name()))
+            return applicantBaseUrl + PAGE_404;
+        return PAGE_404;
     }
 
     @GetMapping("/redirect-after-login")

--- a/src/main/resources/db/Users-setup-LOCAL.sql
+++ b/src/main/resources/db/Users-setup-LOCAL.sql
@@ -1,0 +1,35 @@
+INSERT INTO public.gap_users(gap_user_id, email, sub, dept_id,
+login_journey_state, cola_sub, created)
+VALUES
+(1, 'test.applicant@gov.uk',
+'urn:fdc:gov.uk:2022:ibd2rz2CgyidndXyq2zyfcnQwyYI57h34vMlSr88AAa', null,
+'PRIVACY_POLICY_PENDING', null, null),
+(2, 'test.admin@gov.uk',
+'urn:fdc:gov.uk:2022:ibd2rz2CgyidndXyq2zyfcnQwyYI57h34vMlSr22TTt', 1,
+'PRIVACY_POLICY_PENDING', null, null),
+(3, 'test.super-admin@gov.uk',
+'urn:fdc:gov.uk:2022:ibd2rz2CgyidndXyq2zyfcnQwyYI57h34vMlSr97YUg', 1,
+'PRIVACY_POLICY_PENDING', null, null),
+(4, 'test.tech-supporter@gov.uk',
+ 'urn:fdc:gov.uk:2022:ibd2rz2CgyidndXyq2zyfcnQwyYI57h34vMlSr00Sup', 1,
+  'PRIVACY_POLICY_PENDING', null, null);
+
+
+
+INSERT INTO roles_users (roles_id, users_gap_user_id) VALUES(1, 1);
+INSERT INTO roles_users (roles_id, users_gap_user_id) VALUES(2, 1);
+INSERT INTO roles_users (roles_id, users_gap_user_id) VALUES(1, 2);
+INSERT INTO roles_users (roles_id, users_gap_user_id) VALUES(2, 2);
+INSERT INTO roles_users (roles_id, users_gap_user_id) VALUES(3, 2);
+INSERT INTO roles_users (roles_id, users_gap_user_id) VALUES(2, 3);
+INSERT INTO roles_users (roles_id, users_gap_user_id) VALUES(3, 3);
+INSERT INTO roles_users (roles_id, users_gap_user_id) VALUES(4, 3);
+INSERT INTO roles_users (roles_id, users_gap_user_id) VALUES(5, 3);
+INSERT INTO roles_users (roles_id, users_gap_user_id) VALUES(1, 3);
+INSERT INTO roles_users (roles_id, users_gap_user_id) VALUES(1, 4);
+INSERT INTO roles_users (roles_id, users_gap_user_id) VALUES(2, 4);
+INSERT INTO roles_users (roles_id, users_gap_user_id) VALUES(5, 4);
+
+
+--remember to create the TECH_SUPPORTER user in the gapapply DB in the tech_support_user table
+--INSERT INTO tech_support_user (id, funder_id, user_sub) VALUES(1, 1, 'urn:fdc:gov.uk:2022:ibd2rz2CgyidndXyq2zyfcnQwyYI57h34vMlSr00Sup');


### PR DESCRIPTION
[GAP-2587](https://technologyprogramme.atlassian.net/browse/GAP-2587)

## Description

if a user was logged in, and tried to access any other subdomain not within his role capabilities, the user service was redirecting the user to it's dashboard.
we now implemented logic to redirect the user to a 404/page based on the user role 
Ticket # and link

Summary of the changes and the related issue. List any dependencies that are required for this change:
https://github.com/cabinetoffice/gap-find-apply-web/pull/440

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [x] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.


[GAP-2587]: https://technologyprogramme.atlassian.net/browse/GAP-2587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ