### PR TITLE
GAP-2599: Extend admin jwt session

### DIFF
--- a/src/main/java/gov/cabinetoffice/gapuserservice/config/JwtProperties.java
+++ b/src/main/java/gov/cabinetoffice/gapuserservice/config/JwtProperties.java
@@ -20,6 +20,8 @@ public class JwtProperties {
      */
     private Integer expiresAfter;
 
+    private Integer adminExpiresAfter;
+
     private String signingKey;
 
     private String issuer;

--- a/src/main/java/gov/cabinetoffice/gapuserservice/service/jwt/impl/CustomJwtServiceImpl.java
+++ b/src/main/java/gov/cabinetoffice/gapuserservice/service/jwt/impl/CustomJwtServiceImpl.java
@@ -136,7 +136,7 @@ public class CustomJwtServiceImpl implements JwtService {
         }
     }
 
-    public String generateToken(Map<String, String> claims) {
+    public String generateToken(final Map<String, String> claims, final boolean isAdmin) {
         JWTClaimsSet.Builder jwtClaimsSet = new JWTClaimsSet.Builder();
         jwtClaimsSet.jwtID(UUID.randomUUID().toString());
         for (Map.Entry<String, String> entry : claims.entrySet()) {
@@ -144,8 +144,7 @@ public class CustomJwtServiceImpl implements JwtService {
         }
 
         jwtClaimsSet.issueTime(new Date())
-                .expirationTime(new Date(ZonedDateTime.now(clock).toInstant().toEpochMilli()
-                        + (jwtProperties.getExpiresAfter() * 1000 * 60)))
+                .expirationTime(generateExpiryDate(isAdmin))
                 .issuer(jwtProperties.getIssuer())
                 .audience(jwtProperties.getAudience());
 
@@ -169,6 +168,12 @@ public class CustomJwtServiceImpl implements JwtService {
                 Base64.encodeBase64URLSafeString(header.getBytes(StandardCharsets.UTF_8)),
                 Base64.encodeBase64URLSafeString(payload.getBytes(StandardCharsets.UTF_8)),
                 Base64.encodeBase64URLSafeString(signedResponse.signature().asByteArray()));
+    }
+
+    private Date generateExpiryDate(final boolean isAdmin) {
+        final Integer expiresAfterInMinutes = isAdmin ? jwtProperties.getAdminExpiresAfter() : jwtProperties.getExpiresAfter();
+        final int expiresAfterInMilliseconds = expiresAfterInMinutes * 1000 * 60;
+        return new Date(ZonedDateTime.now(clock).toInstant().toEpochMilli() + expiresAfterInMilliseconds);
     }
 
     private boolean isTokenInBlacklist(final String customJwt) {

--- a/src/main/java/gov/cabinetoffice/gapuserservice/web/LoginControllerV2.java
+++ b/src/main/java/gov/cabinetoffice/gapuserservice/web/LoginControllerV2.java
@@ -166,7 +166,7 @@ public class LoginControllerV2 {
 
         final User user = oneLoginUserService.createOrGetUserFromInfo(userInfo);
 
-        final Cookie customJwtCookie = addCustomJwtCookie(response, userInfo, idToken);
+        final Cookie customJwtCookie = addCustomJwtCookie(response, userInfo, idToken, user.isAdmin());
 
         //recreate state cookie and set age to 0 to delete it. Avoids possible unwanted redirection if state cookie persist
         deleteStateCookie(response);
@@ -229,10 +229,12 @@ public class LoginControllerV2 {
         return oneLoginService.logoutUser(customJWTCookie, response);
     }
 
-    private Cookie addCustomJwtCookie(final HttpServletResponse response, final OneLoginUserInfoDto userInfo,
-            final String idToken) {
+    private Cookie addCustomJwtCookie(final HttpServletResponse response,
+                                      final OneLoginUserInfoDto userInfo,
+                                      final String idToken,
+                                      final boolean isAdmin) {
         final Map<String, String> customJwtClaims = oneLoginService.generateCustomJwtClaims(userInfo, idToken);
-        final String customServiceJwt = customJwtService.generateToken(customJwtClaims);
+        final String customServiceJwt = customJwtService.generateToken(customJwtClaims, isAdmin);
         final Cookie customJwt = WebUtil.buildSecureCookie(userServiceCookieName, customServiceJwt);
         response.addCookie(customJwt);
         return customJwt;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,8 +40,9 @@ blacklist-scheduler.cronExpression=0 01 0 * * ?
 blacklist-scheduler.lock.atMostFor=30m
 blacklist-scheduler.lock.atLeastFor=5m
 
-# JWT properties - FIXME placeholder values
+# JWT properties
 jwt.expires-after=60
+jwt.admin-expires-after=360
 jwt.signing-key=McQfTjWnZr4u7x!A%D*G-KaNdRgUkXp2
 jwt.issuer=http://localhost:8082
 jwt.audience=FGP

--- a/src/test/java/gov/cabinetoffice/gapuserservice/web/LoginControllerV2Test.java
+++ b/src/test/java/gov/cabinetoffice/gapuserservice/web/LoginControllerV2Test.java
@@ -152,7 +152,7 @@ class LoginControllerV2Test {
 
             final RedirectView methodResponse = loginController.login(redirectUrl, request, response);
 
-            verify(customJwtService, times(0)).generateToken(any());
+            verify(customJwtService, times(0)).generateToken(any(), eq(false));
             assertThat(methodResponse.getUrl()).isEqualTo(redirectUrl.get());
         }
 
@@ -169,7 +169,7 @@ class LoginControllerV2Test {
                     .thenReturn(true);
             final RedirectView methodResponse = loginController.login(redirectUrl, request, response);
 
-            verify(customJwtService, times(0)).generateToken(any());
+            verify(customJwtService, times(0)).generateToken(any(), eq(false));
             assertThat(methodResponse.getUrl()).isEqualTo(configProperties.getDefaultRedirectUrl());
         }
     }
@@ -280,7 +280,7 @@ class LoginControllerV2Test {
             when(oneLoginService.decodeTokenId(any())).thenReturn(idTokenDtoBuilder.build());
             when(oneLoginService.decodeStateCookie(any())).thenReturn(stateCookieDtoBuilder.build());
             when(oneLoginService.generateCustomJwtClaims(any(), any())).thenReturn(claims);
-            when(customJwtService.generateToken(claims)).thenReturn("jwtToken");
+            when(customJwtService.generateToken(claims, false)).thenReturn("jwtToken");
 
             loginController.redirectAfterLogin(stateCookie, request, response, code, state);
 


### PR DESCRIPTION
Admin middleware now requires user service JWT, which effectively shortened their session from 6 hours to 1

This change allows for us to customise the admin session duration separately from applicants

https://eu-west-2.console.aws.amazon.com/codesuite/codecommit/repositories/GAP-infra/pull-requests/359/details?region=eu-west-2