### PR TITLE
GAP-2653: Logout actually deletes user service token

### DIFF
--- a/src/main/java/gov/cabinetoffice/gapuserservice/service/user/OneLoginUserService.java
+++ b/src/main/java/gov/cabinetoffice/gapuserservice/service/user/OneLoginUserService.java
@@ -67,6 +67,9 @@ public class OneLoginUserService {
     @Value("${find-a-grant.url}")
     private String findFrontend;
 
+    @Value("${jwt.cookie-domain}")
+    public String userServiceCookieDomain;
+
     public Page<User> getPaginatedUsers(Pageable pageable, UserQueryDto userQueryDto) {
         final Map<UserQueryCondition, BiFunction<UserQueryDto, Pageable, Page<User>>> conditionMap = createUserQueryConditionMap();
         final UserQueryCondition condition = userQueryDto.getCondition();
@@ -369,7 +372,7 @@ public class OneLoginUserService {
                 new Cookie(userServiceCookieName, null),
                 Boolean.TRUE,
                 Boolean.TRUE,
-                null
+                userServiceCookieDomain
         );
         userTokenCookie.setMaxAge(0);
         response.addCookie(userTokenCookie);


### PR DESCRIPTION
Previously in the logout endpoint, when we set the `user-service-token` max to 0, the domain is set to null and thus its actually making a new cookie with a max age of 0 rather than replacing the existing `user-service-token`. This PR should set the domain ensuring it overrides the cookie correctly rather than making a new one