### PR TITLE
Updated upload-artifact action version to v4

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -40,7 +40,7 @@ jobs:
             --disableOssIndex true
 
       - name: Upload Test results
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
           name: DependencyCheck report
           path: ${{github.workspace}}/reports

--- a/.github/workflows/pushImage.yml
+++ b/.github/workflows/pushImage.yml
@@ -42,7 +42,7 @@ jobs:
             --disableOssIndex true
 
       - name: Upload Test results
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
           name: DependencyCheck report
           path: ${{github.workspace}}/reports
@@ -109,7 +109,7 @@ jobs:
         run: docker save --output ${{ steps.docker-image-name.outputs.name }}.tar $ECR_REGISTRY/gap-user-service:${{ env.BUILD_VERSION }}
 
       - name: Upload Docker image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.docker-image-name.outputs.name }}
           path: ${{ steps.docker-image-name.outputs.name }}.tar


### PR DESCRIPTION
Updates upload-artifact version from deprecated v3 to v4. See https://technologyprogramme.atlassian.net/browse/LSS-712
